### PR TITLE
Add launcher's node_modules to NR NODE_PATH

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,8 +25,8 @@ options.logBufferMax = options.logBufferMax || 1000
 let ext = process.platform == "win32" ? ".cmd" : ""
 
 options.execPath = undefined
-for (let i=0; i<process.mainModule.paths.length; i++) {
-  let execPath = path.join(process.mainModule.paths[i], '.bin', `node-red${ext}`)
+for (let i=0; i<require.main.paths.length; i++) {
+  let execPath = path.join(require.main.paths[i], '.bin', `node-red${ext}`)
   if (fs.existsSync(execPath)) {
     options.execPath = execPath
     break

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -108,6 +108,8 @@ class Launcher {
             appEnv.NODE_RED_ENABLE_SAFE_MODE = true
         }
 
+        appEnv.NODE_PATH = path.join(request.main.path, "../..")
+
         const processOptions = {
             windowsHide: true,
             cwd: this.settings.rootDir,

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -108,7 +108,10 @@ class Launcher {
             appEnv.NODE_RED_ENABLE_SAFE_MODE = true
         }
 
-        appEnv.NODE_PATH = path.join(require.main.path, "../..")
+        appEnv.NODE_PATH = [
+            path.join(require.main.path, "node_modules"),
+            path.join(require.main.path, "..", "..")
+        ].join(path.delimiter)
 
         const processOptions = {
             windowsHide: true,

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -108,7 +108,7 @@ class Launcher {
             appEnv.NODE_RED_ENABLE_SAFE_MODE = true
         }
 
-        appEnv.NODE_PATH = path.join(request.main.path, "../..")
+        appEnv.NODE_PATH = path.join(require.main.path, "../..")
 
         const processOptions = {
             windowsHide: true,


### PR DESCRIPTION
This adds the node_modules dir that includes the storage/logger/auth plugins to the NR search path