### PR TITLE
Apply project settings to settings.js

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -1,4 +1,43 @@
 function getSettingsFile(settings) {
+
+    const projectSettings = {
+        httpAdminRoot: '',
+        disableEditor: '',
+        codeEditor: 'monaco',
+        palette: {
+            allowInstall: true,
+            nodesExcludes: []
+        },
+        modules: {
+            allowInstall: true
+        }
+    }
+
+    if (settings.settings) {
+        // Template/project supplied settings
+        if (settings.settings.httpAdminRoot !== undefined) {
+            projectSettings.httpAdminRoot = `    httpAdminRoot: '${settings.settings.httpAdminRoot}',`
+        }
+        if (settings.settings.disableEditor !== undefined) {
+            projectSettings.disableEditor = `    disableEditor: ${settings.settings.disableEditor},`
+        }
+        if (settings.settings.codeEditor) {
+            projectSettings.codeEditor = settings.settings.codeEditor
+        }
+        if (settings.settings.palette?.allowInstall !== undefined) {
+            projectSettings.palette.allowInstall = settings.settings.palette.allowInstall
+        }
+        if (settings.settings.palette?.nodesExcludes !== undefined) {
+            projectSettings.palette.nodesExcludes = settings.settings.palette.nodesExcludes.split(',').map(fn => fn.trim()).filter(fn => fn.length > 0)
+        }
+        if (settings.settings.modules?.allowInstall !== undefined) {
+            projectSettings.modules.allowInstall = settings.settings.modules.allowInstall
+        }
+
+    }
+
+
+
     const settingsTemplate = `
 module.exports = {
     flowFile: 'flows.json',
@@ -9,6 +48,8 @@ module.exports = {
         clientID: '${settings.clientID}',
         clientSecret: '${settings.clientSecret}'
     }),
+    ${projectSettings.httpAdminRoot}
+    ${projectSettings.disableEditor}
     storageModule: require('@flowforge/nr-storage'),
     httpStorage: {
         projectID: '${settings.projectID}',
@@ -17,37 +58,37 @@ module.exports = {
     },
     logging: {
         console: { level: 'info', metric: false, audit: false, handler: () => {
-            const levelNames = {
-                10: "fatal",
-                20: "error",
-                30: "warn",
-                40: "info",
-                50: "debug",
-                60: "trace",
-                98: "audit",
-                99: "metric"
-            }
-            return (msg) => {
-                let message = msg.msg;
-                try {
-                    if (typeof message === 'object' && message !== null && message.toString() === '[object Object]' && message.message) {
-                        message = message.message;
-                    }
-                } catch(e){
-                    message = 'Exception trying to log: '+util.inspect(message);
+                const levelNames = {
+                    10: "fatal",
+                    20: "error",
+                    30: "warn",
+                    40: "info",
+                    50: "debug",
+                    60: "trace",
+                    98: "audit",
+                    99: "metric"
                 }
-                console.log(JSON.stringify({
-                    ts: Date.now(),
-                    level: levelNames[msg.level],
-                    type: msg.type,
-                    name: msg.name,
-                    id:msg.id,
-                    msg: message
-                }))
+                return (msg) => {
+                    let message = msg.msg;
+                    try {
+                        if (typeof message === 'object' && message !== null && message.toString() === '[object Object]' && message.message) {
+                            message = message.message;
+                        }
+                    } catch(e){
+                        message = 'Exception trying to log: '+util.inspect(message);
+                    }
+                    console.log(JSON.stringify({
+                        ts: Date.now(),
+                        level: levelNames[msg.level],
+                        type: msg.type,
+                        name: msg.name,
+                        id:msg.id,
+                        msg: message
+                    }))
+                }
             }
-        }
 
-    },
+        },
         auditLogger: {
             level: 'off', audit: true, handler: require('@flowforge/nr-audit-logger'),
             loggingURL: '${settings.auditURL}',
@@ -63,9 +104,21 @@ module.exports = {
             title: 'FlowForge'
         },
         codeEditor: {
-            lib: "monaco"
+            lib: '${projectSettings.codeEditor}'
         }
-    }
+    },
+    nodesExcludes: ${JSON.stringify(projectSettings.palette.nodesExcludes)},
+    externalModules: {
+        autoInstall: true,
+        palette: {
+            allowInstall: ${projectSettings.palette.allowInstall},
+            allowUpload: false
+        },
+        modules: {
+            allowInstall: ${projectSettings.modules.allowInstall}
+        }
+    },
+    functionExternalModules: ${projectSettings.modules.allowInstall}
 }`
     return settingsTemplate
 }


### PR DESCRIPTION
This adds support for some project settings to be applied to the runtime settings file.

This works for:

 - `httpAdminRoot`
 - `disableEditor`
 - `codeEditor`
 - `palette.allowInstall`
 - `nodesExcludes` (provided as `palette.nodesExcludes` over the api)
 - `modules.allowInstall`

If these settings aren't provided, it applies values consistent with 0.2 behaviour.