### PR TITLE
Put NR into safemode when crash loop detected

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -176,9 +176,17 @@ class Launcher {
                     }
                     avg /= MAX_RESTART_COUNT
                     if (avg < MIN_RESTART_TIME) {
-                        // restarting too fast
-                        this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Stopping' })
-                        this.targetState = States.STOPPED
+                        // restarting too fast - go to safe mode
+                        // reset the startTime list
+                        this.startTime = []
+                        if (this.targetState === States.SAFE) {
+                            this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected whilst in safe mode. Stopping.' })
+                            this.targetState = States.STOPPED
+                        } else {
+                            this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Restarting in safe mode' })
+                            this.targetState = States.SAFE
+                            this.start()
+                        }
                     } else {
                         this.start()
                     }


### PR DESCRIPTION
Related to https://github.com/flowforge/flowforge/issues/530 - this PR adds the code to put a NR instance into safe mode if a crash loop is detected.

Just in case something *really* bad is happening - if the crash loop is detected when we thought we were running in Safe mode, it doesn't restart.
