### PR TITLE
Redirect user back to ff platform on logout

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -111,6 +111,9 @@ module.exports = {
         header: {
             title: 'FlowForge'
         },
+        logout: {
+            redirect: '${settings.forgeURL}/project/${settings.projectID}'
+        },
         codeEditor: {
             lib: '${projectSettings.codeEditor}'
         }


### PR DESCRIPTION
Part of #31 

When a user selects 'logout' from the user menu within Node-RED, they currently get the page reloaded and prompted with the NR login dialog again.

With https://github.com/flowforge/flowforge-nr-auth/pull/15 being added to the auth configuration, when using NR 3.x, we will no longer show the login dialog, and go straight to logging them in.

The side-effect of that means selecting logout will log them out, then auto log-in again.

This PR improves the UX by redirecting them back to the FF project page when they logout.