### PR TITLE
Initial theming support

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -259,6 +259,7 @@ class Launcher {
             this.state = States.STOPPED
         }
     }
+
     async revokeUserToken (token) { // logout:nodered(step-5)
         this.logBuffer.add({ level: 'system', msg: 'Node-RED logout requested' })
         if (this.state !== States.RUNNING) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -54,6 +54,17 @@ class Launcher {
         this.settings.clientID = process.env.FORGE_CLIENT_ID
         this.settings.clientSecret = process.env.FORGE_CLIENT_SECRET
         this.settings.credentialSecret = process.env.FORGE_NR_SECRET
+
+        // setup nodeDir to include the path to additional nodes and plugins
+        const nodesDir = []
+        if (Array.isArray(this.settings.nodesDir) && this.settings.nodesDir.length) {
+            nodesDir.push(...this.settings.nodesDir)
+        } else if (this.settings.nodesDir && typeof this.settings.nodesDir === 'string') {
+            nodesDir.push(this.settings.nodesDir)
+        }
+        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowforge', 'nr-theme').replace(/\\/g, '/')) // MVP: fixed to loading FF theme
+        this.settings.nodesDir = nodesDir
+
         const settingsFileContent = getSettingsFile(this.settings)
         const settingsPath = path.join(this.settings.rootDir, this.settings.userDir, 'settings.js')
         fs.writeFileSync(settingsPath, settingsFileContent)

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -33,7 +33,7 @@ function getSettingsFile (settings) {
             projectSettings.codeEditor = settings.settings.codeEditor
         }
         if (settings.settings.theme) {
-            projectSettings.theme = `theme: '${settings.settings.theme}',`
+            projectSettings.theme = settings.settings.theme
         }
         if (settings.settings.page?.title) {
             projectSettings.page_title = settings.settings.page.title
@@ -69,6 +69,10 @@ function getSettingsFile (settings) {
         if (settings.settings.modules?.denyList !== undefined) {
             projectSettings.modules.denyList = settings.settings.modules.denyList
         }
+    }
+
+    if (projectSettings.theme) {
+        projectSettings.theme = `theme: '${projectSettings.theme}',`
     }
 
     let nodesDir = ''

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -3,6 +3,11 @@ function getSettingsFile (settings) {
         httpAdminRoot: '',
         disableEditor: '',
         codeEditor: 'monaco',
+        theme: '',
+        page_title: 'FlowForge',
+        page_favicon: '',
+        header_title: 'FlowForge',
+        header_url: `url: '${settings.forgeURL}/project/${settings.projectID}'`,
         palette: {
             allowInstall: true,
             nodesExcludes: []
@@ -22,6 +27,22 @@ function getSettingsFile (settings) {
         }
         if (settings.settings.codeEditor) {
             projectSettings.codeEditor = settings.settings.codeEditor
+        }
+        if (settings.settings.theme !== undefined) {
+            projectSettings.theme = `theme: '${settings.settings.theme}',`
+        }
+        if (settings.settings.page?.title !== undefined) {
+            projectSettings.page_title = settings.settings.page?.title
+        }
+        projectSettings.page_favicon = 'favicon: "/theme/css/favicon.ico",' // TODO: get from theme
+        if (settings.settings.page?.favicon !== undefined) {
+            projectSettings.page_favicon = `favicon: "${settings.settings.page?.favicon}",`
+        }
+        if (settings.settings.header?.title !== undefined) {
+            projectSettings.header_title = settings.settings.header?.title
+        }
+        if (settings.settings.header?.url !== undefined) {
+            projectSettings.header_url = settings.settings.header?.url
         }
         if (settings.settings.palette?.allowInstall !== undefined) {
             projectSettings.palette.allowInstall = settings.settings.palette.allowInstall
@@ -105,11 +126,14 @@ module.exports = {
         }
     },
     editorTheme: {
+        ${projectSettings.theme}
         page: {
-            title: 'FlowForge'
+            title: '${projectSettings.page_title}',
+            ${projectSettings.page_favicon}
         },
         header: {
-            title: 'FlowForge'
+            title: '${projectSettings.header_title}',
+            ${projectSettings.header_url}
         },
         logout: {
             redirect: '${settings.forgeURL}/project/${settings.projectID}'

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -32,21 +32,21 @@ function getSettingsFile (settings) {
         if (settings.settings.codeEditor) {
             projectSettings.codeEditor = settings.settings.codeEditor
         }
-        if (settings.settings.theme !== undefined) {
+        if (settings.settings.theme) {
             projectSettings.theme = `theme: '${settings.settings.theme}',`
         }
-        if (settings.settings.page?.title !== undefined) {
-            projectSettings.page_title = settings.settings.page?.title
+        if (settings.settings.page?.title) {
+            projectSettings.page_title = settings.settings.page.title
         }
         projectSettings.page_favicon = 'favicon: "/theme/css/favicon.ico",' // TODO: get from theme
-        if (settings.settings.page?.favicon !== undefined) {
-            projectSettings.page_favicon = `favicon: "${settings.settings.page?.favicon}",`
+        if (settings.settings.page?.favicon) {
+            projectSettings.page_favicon = `favicon: "${settings.settings.page.favicon}",`
         }
-        if (settings.settings.header?.title !== undefined) {
-            projectSettings.header_title = settings.settings.header?.title
+        if (settings.settings.header?.title) {
+            projectSettings.header_title = settings.settings.header.title
         }
-        if (settings.settings.header?.url !== undefined) {
-            projectSettings.header_url = settings.settings.header?.url
+        if (settings.settings.header?.url) {
+            projectSettings.header_url = settings.settings.header.url
         }
         if (settings.settings.palette?.allowInstall !== undefined) {
             projectSettings.palette.allowInstall = settings.settings.palette.allowInstall

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -4,7 +4,7 @@ function getSettingsFile (settings) {
         httpAdminRoot: '',
         disableEditor: '',
         codeEditor: 'monaco',
-        theme: '',
+        theme: 'forge-light',
         page_title: 'FlowForge',
         page_favicon: '',
         header_title: 'FlowForge',
@@ -71,6 +71,10 @@ function getSettingsFile (settings) {
         }
     }
 
+    let nodesDir = ''
+    if (settings.nodesDir && settings.nodesDir.length) {
+        nodesDir = `nodesDir: ${JSON.stringify(settings.nodesDir)},`
+    }
     const settingsTemplate = `
 module.exports = {
     flowFile: 'flows.json',
@@ -130,6 +134,7 @@ module.exports = {
             token: '${settings.projectToken}'
         }
     },
+    ${nodesDir}
     editorTheme: {
         ${projectSettings.theme}
         page: {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
         "@flowforge/nr-audit-logger": "^0.6.0",
         "@flowforge/nr-auth": "^0.6.0",
         "@flowforge/nr-storage": "^0.6.0",
+        "@flowforge/nr-theme": "^0.0.1",
         "body-parser": "^1.20.0",
         "command-line-args": "^5.2.1",
         "express": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
         "@flowforge/nr-audit-logger": "^0.6.0",
         "@flowforge/nr-auth": "^0.6.0",
         "@flowforge/nr-storage": "^0.6.0",
-        "@flowforge/nr-theme": "^0.0.1",
+        "@flowforge/nr-theme": "^0.1.0",
         "body-parser": "^1.20.0",
         "command-line-args": "^5.2.1",
         "express": "^4.18.1",


### PR DESCRIPTION
Adds elements to support basic theming. This PR works in tandem with flowforge PR https://github.com/flowforge/flowforge/pull/613

<br>

_UPDATED 21-06-2022_

<br>

This part of the "Initial Theming" PRs is to make entries in the settings.js file for the theme choice, title and header icon/URL link back to flowforge and `nodesDir` for theme plugin.



## Implementation Details...

* Updates the settings template to include minimal theme related settings
* Adds entry  `nodesDir: ["{launcher}/node_modules/@flowforge/nr-theme"],` 
  * NOTE: Only NR `3.0.0-beta.3` and above supports loading plugins from `nodesDir`
  * NOTE: Future plugins and nodes can also be loaded by adding to the  `nodesDir` array
* Adds dependancy to `@flowforge/nr-theme` in package.json

### template additions
* theme // configurable - defaults to 'forge-light'
* page_title: 'FlowForge', // not configurable at this time 
* page_favicon: '', // not configurable at this time 
* header_title: // configurable - defaults to 'FlowForge'
* header_url //not configurable, set in src
* nodesDir //not configurable at this time (fixed to `{launcher}/node_modules/@flowforge/nr-theme`)
Example...

```js
    nodesDir: [ "{launcher}/node_modules/@flowforge/nr-theme" ],
    editorTheme: {
        theme: 'forge-light',
        page: {
            title: 'FlowForge',
            favicon: 'theme/favicon.png'
        },
        header: {
            title: 'My Project',
            url: 'https://app.flowforge/xxxxx'
        },
        ...
```