### PR TITLE
Fix win32 stopping projects and "crash" status

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -136,7 +136,9 @@ class Launcher {
             const memLimit = Math.round(this.settings.stack.memory * 0.75)
             processArguments.push(`--max-old-space-size=${memLimit}`)
         }
-
+        this.options.execPathJs = path.join(this.options.nodeRedPath, 'node_modules', 'node-red', 'red.js')
+        processArguments.unshift(this.options.execPathJs)
+        this.options.execPath = process.execPath
         this.proc = childProcess.spawn(
             this.options.execPath,
             processArguments,
@@ -161,6 +163,11 @@ class Launcher {
 
         this.proc.on('exit', async (code, signal) => {
             this.logBuffer.add({ level: 'system', msg: `Node-RED exited rc=${code} signal=${signal}` })
+            // When childProcess.kill() is executed on windows, the exit code is null and the signal is 'SIGTERM'.
+            // So long as the process was instructed to STOP and its state is STOPPED, consider this a clean exit
+            if (process.platform === 'win32' && code === null && signal === 'SIGTERM' && this.targetState === States.STOPPED && this.state === States.STOPPED) {
+                code = 0
+            }
             if (code === 0) {
                 this.state = States.STOPPED
                 await this.logAuditEvent('stopped')


### PR DESCRIPTION
fixes https://github.com/flowforge/flowforge/issues/530

While setting up the FF developer environment and testing on windows box, issues around project status when stopping / starting projects were discovered.   

This PR fixes these issues...
* Project cannot be stopped
* Project status "crashed"
* Launching node instead of the batch file (so the correct PID is obtained)
