### PR TITLE
Report node/nr/launcher versions in /info endpoint response

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,23 @@ if (!options.execPath) {
     process.exit(1)
 }
 
+// Gather versions numbers for reporting to the platform
+options.versions = {
+    node: process.version.replace(/^v/, ''),
+    launcher: require('./package.json').version
+}
+
+// Go find Node-RED's package.json
+const nrModulePath = path.relative(__dirname, path.join(path.dirname(options.execPath), '..', 'node-red', 'package.json'))
+console.log(__dirname)
+console.log(nrModulePath)
+try {
+    const nrPkg = require(nrModulePath)
+    options.versions['node-red'] = nrPkg.version
+} catch (err) {
+    options.versions['node-red'] = err.toString()
+}
+
 async function main () {
     const launcher = new Launcher(options)
     const adminInterface = new AdminInterface(options, launcher)

--- a/index.js
+++ b/index.js
@@ -59,8 +59,6 @@ options.versions = {
 
 // Go find Node-RED's package.json
 const nrModulePath = path.relative(__dirname, path.join(path.dirname(options.execPath), '..', 'node-red', 'package.json'))
-console.log(__dirname)
-console.log(nrModulePath)
 try {
     const nrPkg = require(nrModulePath)
     options.versions['node-red'] = nrPkg.version

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -18,7 +18,8 @@ class AdminInterface {
             const info = {
                 id: this.options.project,
                 state: this.launcher.getState(),
-                lastStartTime: this.launcher.getLastStartTime()
+                lastStartTime: this.launcher.getLastStartTime(),
+                versions: options.versions
             }
             response.send(info)
         })


### PR DESCRIPTION
This adds version information to the `/info` admin endpoint provided by the launcher.

It includes:
 - node.js version
 - node-red version
 - launcher version

This will allow the platform to track what versions are in use, and where appropriate, prompt the user to upgrade.

Part of https://github.com/flowforge/flowforge/issues/576