### PR TITLE
Map FlowForge logout to nodered auth/revoke

### DIFF
--- a/lib/admin.js
+++ b/lib/admin.js
@@ -58,6 +58,9 @@ class AdminInterface {
                     await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
                     response.send({})
                 }
+            } else if (request.body.cmd === 'logout') { // logout:nodered(step-4)
+                await launcher.logoutNodeRED(request.body.token) // logout:nodered(step-5)
+                response.send({})
             } else if (request.body.cmd === 'shutdown') {
                 await launcher.stop()
                 response.send({})

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -59,7 +59,7 @@ class AdminInterface {
                     response.send({})
                 }
             } else if (request.body.cmd === 'logout') { // logout:nodered(step-4)
-                await launcher.logoutNodeRED(request.body.token) // logout:nodered(step-5)
+                await launcher.revokeUserToken(request.body.token) // logout:nodered(step-5)
                 response.send({})
             } else if (request.body.cmd === 'shutdown') {
                 await launcher.stop()

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -265,10 +265,9 @@ class Launcher {
                 pragma: 'no-cache',
                 Referer: this.settings.baseURL
             }
-            console.log({ adminAPI, json, headers })
             await got.post(adminAPI, { json, headers })
         } catch (error) {
-            console.error('Caught error in logoutnodered', error)
+            this.logBuffer.add({ level: 'system', msg: `Error logging out Node-RED: ${error.toString()}` })
         }
     }
 }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -248,7 +248,7 @@ class Launcher {
             this.state = States.STOPPED
         }
     }
-    async logoutNodeRED (token) { // logout:nodered(step-5)
+    async revokeUserToken (token) { // logout:nodered(step-5)
         this.logBuffer.add({ level: 'system', msg: 'Node-RED logout requested' })
         if (this.state !== States.RUNNING) {
             // not running

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -248,6 +248,29 @@ class Launcher {
             this.state = States.STOPPED
         }
     }
+    async logoutNodeRED (token) { // logout:nodered(step-5)
+        this.logBuffer.add({ level: 'system', msg: 'Node-RED logout requested' })
+        if (this.state !== States.RUNNING) {
+            // not running
+            return
+        }
+        try {
+            const adminAPI = `${this.settings.baseURL}/auth/revoke`
+            const json = { token: token, noRedirect: true }
+            const headers = {
+                authorization: 'Bearer ' + token,
+                'cache-control': 'no-cache',
+                'content-type': 'application/json',
+                'node-red-api-version': 'v2',
+                pragma: 'no-cache',
+                Referer: this.settings.baseURL
+            }
+            console.log({ adminAPI, json, headers })
+            await got.post(adminAPI, { json, headers })
+        } catch (error) {
+            console.error('Caught error in logoutnodered', error)
+        }
+    }
 }
 
 module.exports = { Launcher, States }


### PR DESCRIPTION
fixes https://github.com/flowforge/flowforge/issues/442

## NOTE
NOTE: this PR is to be reviewed and merged as 3 of 3 parts...

1. https://github.com/flowforge/flowforge/pull/643
1. https://github.com/flowforge/flowforge-driver-localfs/pull/48
1. https://github.com/flowforge/flowforge-nr-launcher/pull/40

Also related...
1. https://github.com/flowforge/flowforge-driver-docker/pull/24
1. https://github.com/flowforge/flowforge-driver-k8s/pull/39

## Changes
* Refer to [flowforge #643](https://github.com/flowforge/flowforge/pull/643) for steps 1+2 in this process
* Refer to [localfs driver #48](https://github.com/flowforge/flowforge-driver-localfs/pull/48) for step 3 in this process
* Maps STEP 4 to call to `launcher.logoutNodeRED` in `lib/admin.js` 
* Adds function `logoutNodeRED (token)` to `lib/launcher.js` 
  * Builds the API call to the node-red instance:port to call `auth/revoke`  (STEP 5) 

