### PR TITLE
Remove Node-RED as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
         "command-line-args": "^5.2.1",
         "express": "^4.18.1",
         "got": "^11.8.5",
-        "node-red": "^2.2.1",
         "ws": "^8.7.0"
     },
     "devDependencies": {


### PR DESCRIPTION
With stacks we no longer need a default Node-RED install to use so remove a large amount of duplicate install.

Fixes #47 