### PR TITLE
Fix search path for theme

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -63,6 +63,7 @@ class Launcher {
             nodesDir.push(this.settings.nodesDir)
         }
         nodesDir.push(path.join(require.main.path, 'node_modules', '@flowforge', 'nr-theme').replace(/\\/g, '/')) // MVP: fixed to loading FF theme
+        nodesDir.push(path.join(require.main.path, '..', 'nr-theme').replace(/\\/g, '/')) // MVP: fixed to loading FF theme
         this.settings.nodesDir = nodesDir
 
         const settingsFileContent = getSettingsFile(this.settings)


### PR DESCRIPTION
Add right relative path for localfs driver (should also be right for docker/k8s but workaround in place)