### PR TITLE
add runtimeState

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -192,6 +192,10 @@ module.exports = {
         teamID:  '${settings.teamID}',
         projectID: '${settings.projectID}',
         projectLink: ${JSON.stringify(projectSettings.projectLink)}
+    },
+    runtimeState: {
+        enabled: true,
+        ui: true
     }
 }`
     return settingsTemplate


### PR DESCRIPTION
Adds the runtimeState to settings.js 
Closes https://github.com/flowforge/flowforge/issues/839

Have tested with 3.0.1 stacks and 2.2.2 stacks,  as expected 2.x ignores the setting fine.

Existing projects would need to update their stack (or have a container restart) in order to pickup the feature.