### PR TITLE
Add FORGE_LICENSE_TYPE env so launcher can enable EE only features

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -55,6 +55,7 @@ class Launcher {
         this.settings.teamID = process.env.FORGE_TEAM_ID
         this.settings.clientSecret = process.env.FORGE_CLIENT_SECRET
         this.settings.credentialSecret = process.env.FORGE_NR_SECRET
+        this.settings.licenseType = process.env.FORGE_LICENSE_TYPE
         this.settings.broker = this.options.broker
 
         // setup nodeDir to include the path to additional nodes and plugins

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -76,7 +76,7 @@ function getSettingsFile (settings) {
         }
     }
 
-    if (settings.broker) {
+    if (settings.licenseType === 'ee' && settings.broker) {
         // Enable the projectLink nodes if a broker configuration is provided
         projectSettings.projectLink = {
             token: settings.projectToken,


### PR DESCRIPTION
This is needed so the launcher will only write out the projectLink settings if the licenseType is `ee`