### PR TITLE
Remove the explicit paths to theme

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -66,10 +66,7 @@ class Launcher {
         } else if (this.settings.nodesDir && typeof this.settings.nodesDir === 'string') {
             nodesDir.push(this.settings.nodesDir)
         }
-        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowforge', 'nr-theme').replace(/\\/g, '/')) // MVP: fixed to loading FF theme
-        nodesDir.push(path.join(require.main.path, '..', 'nr-theme').replace(/\\/g, '/')) // MVP: fixed to loading FF theme
-        nodesDir.push(path.join(require.main.path, 'node_modules', '@flowforge', 'nr-project-nodes').replace(/\\/g, '/'))
-        nodesDir.push(path.join(require.main.path, '..', 'nr-project-nodes').replace(/\\/g, '/'))
+
         this.settings.nodesDir = nodesDir
 
         const settingsFileContent = getSettingsFile(this.settings)


### PR DESCRIPTION
And the project nodes. No longer needed after fixing localfs container driver

Closes #54

Depends on https://github.com/flowforge/flowforge-driver-localfs/pull/64