### PR TITLE
Get the list of package.json modules from project settings

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,8 +85,11 @@ async function main () {
         await launcher.stop()
         process.exit(0)
     })
-    await launcher.loadSettings()
-    await launcher.start()
+    try {
+        await launcher.loadSettings()
+        await launcher.start()
+    } catch (err) {
+    }
 
     // const wss = new ws.Server({ clientTracking: false, noServer: true })
     //

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -47,16 +47,20 @@ class AdminInterface {
                 await launcher.stop()
                 setTimeout(async () => {
                     // Update the settings
-                    await launcher.loadSettings()
-                    await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
+                    try {
+                        await launcher.loadSettings()
+                        await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
+                    } catch (err) {}
                     response.send({})
                 }, 2000)
             } else if (request.body.cmd === 'start') {
                 if (launcher.getState() === States.RUNNING) {
                     response.status(409).send({ err: 'Already running' })
                 } else {
-                    await launcher.loadSettings()
-                    await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
+                    try {
+                        await launcher.loadSettings()
+                        await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
+                    } catch (err) {}
                     response.send({})
                 }
             } else if (request.body.cmd === 'logout') { // logout:nodered(step-4)

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -77,8 +77,75 @@ class Launcher {
         const settingsPath = path.join(this.settings.rootDir, this.settings.userDir, 'settings.js')
         fs.writeFileSync(settingsPath, settingsFileContent)
 
+        await this.updatePackage()
         this.targetState = this.settings.state || States.RUNNING
         this.logBuffer.add({ level: 'system', msg: `Target state is '${this.targetState}'` })
+    }
+
+    async updatePackage () {
+        const pkgFilePath = path.join(this.settings.rootDir, this.settings.userDir, 'package.json')
+        const packageContent = fs.readFileSync(pkgFilePath, { encoding: 'utf8' })
+        const pkg = JSON.parse(packageContent)
+        const existingDependencies = pkg.dependencies || {}
+        const wantedDependencies = this.settings.settings.palette?.modules || {}
+
+        const existingModules = Object.keys(existingDependencies)
+        const wantedModules = Object.keys(wantedDependencies)
+
+        let changed = false
+        if (existingModules.length !== wantedModules.length) {
+            changed = true
+        } else {
+            existingModules.sort()
+            wantedModules.sort()
+            for (let i = 0; i < existingModules.length; i++) {
+                if (existingModules[i] !== wantedModules[i]) {
+                    changed = true
+                    break
+                }
+                if (existingDependencies[existingModules[i]] !== wantedDependencies[wantedModules[i]]) {
+                    changed = true
+                    break
+                }
+            }
+        }
+
+        if (changed) {
+            this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
+            pkg.dependencies = wantedDependencies
+            fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))
+            console.log('changed!')
+            console.log('got', existingDependencies)
+            console.log('want', this.settings.settings.palette?.modules)
+
+            return new Promise((resolve, reject) => {
+                const child = childProcess.spawn(
+                    'npm',
+                    ['install', '--production', '--no-audit', '--no-update-notifier', '--no-fund'],
+                    { cwd: path.join(this.settings.rootDir, this.settings.userDir) })
+                child.stdout.on('data', (data) => {
+                    this.logBuffer.add({ level: 'system', msg: '[npm] ' + data })
+                })
+                child.stderr.on('data', (data) => {
+                    this.logBuffer.add({ level: 'system', msg: '[npm] ' + data })
+                })
+                child.on('error', (err) => {
+                    this.logBuffer.add({ level: 'system', msg: '[npm] ' + err.toString() })
+                })
+                child.on('close', (code) => {
+                    if (code === 0) {
+                        resolve()
+                    } else {
+                        reject(new Error('Failed to install project dependencies'))
+                    }
+                })
+            }).catch(err => {
+                // Revert the package file to the previous content. That ensures
+                // it will try to install again the next time it attempts to run
+                fs.writeFileSync(pkgFilePath, packageContent)
+                throw err
+            })
+        }
     }
 
     async logAuditEvent (event) {

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -195,7 +195,7 @@ module.exports = {
     },
     nodesExcludes: ${JSON.stringify(projectSettings.palette.nodesExcludes)},
     externalModules: {
-        autoInstall: true,
+        // autoInstall: true,
         palette: {
             allowInstall: ${projectSettings.palette.allowInstall},
             allowUpload: false,

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -16,8 +16,11 @@ describe('Runtime Settings', function () {
     async function loadSettings (content) {
         // Need to fix the node path inside the content to ensure it can find
         // the @flowforge/nr- modules it tries to load
+        // nmPath - when nr-auth is installed in our local node_modules
         const nmPath = path.normalize(path.join(__dirname, '../../../node_modules')).split(path.sep).join('/')
-        content = `module.paths.unshift('${nmPath}'); ${content}`
+        // nmPath2 - when running inside flowforge-dev-env, need to go higher in the tree
+        const nmPath2 = path.normalize(path.join(__dirname, '../../../../../node_modules')).split(path.sep).join('/')
+        content = `module.paths.unshift('${nmPath}', '${nmPath2}'); ${content}`
         const fn = path.normalize(path.join(TMPDIR, `${Math.random().toString(36).substring(2)}.js`)).split(path.sep).join('/')
         await fs.writeFile(fn, content)
         return require(fn)
@@ -47,7 +50,7 @@ describe('Runtime Settings', function () {
 
             settings.should.have.property('nodesExcludes', [])
             settings.should.have.property('externalModules')
-            settings.externalModules.should.have.property('autoInstall', true)
+            settings.externalModules.should.not.have.property('autoInstall')
             settings.externalModules.should.have.property('palette')
             settings.externalModules.palette.should.have.property('allowInstall', true)
             settings.externalModules.palette.should.have.property('allowUpload', false)
@@ -146,7 +149,7 @@ describe('Runtime Settings', function () {
             settings.should.have.property('nodesExcludes', ['abc', 'def'])
 
             settings.should.have.property('externalModules')
-            settings.externalModules.should.have.property('autoInstall', true)
+            settings.externalModules.should.not.have.property('autoInstall')
 
             settings.externalModules.should.have.property('palette')
             settings.externalModules.palette.should.have.property('allowInstall', false)


### PR DESCRIPTION
Companion to https://github.com/flowforge/flowforge/pull/1090

This updates the launcher to update `package.json` with the list of dependencies set by the platform - and run `npm install` prior to starting Node-RED.

### Error handling

Any errors running `npm install` will prevent Node-RED from starting. Those errors are logged back and viewable in the platform logs:

<img width="840" alt="image" src="https://user-images.githubusercontent.com/51083/196237705-d280861d-d9cc-4efe-81ed-3d6958ca5886.png">

That allows the user to know what has gone wrong - and correct the error if it is on their part.