### PR TITLE
Npm install starting

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -185,7 +185,7 @@ class Launcher {
         if (!this.settings) {
             throw new Error('Failed to load settings')
         }
-        if (this.state === States.RUNNING || this.state === States.STARTING) {
+        if (this.state === States.RUNNING) {
             // Already running or starting - no need to start again
             return
         }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -41,6 +41,7 @@ class Launcher {
     }
 
     async loadSettings () {
+        this.state = States.STARTING
         this.logBuffer.add({ level: 'system', msg: 'Loading project settings' })
         const settingsURL = `${this.options.forgeURL}/api/v1/projects/${this.options.project}/settings`
         const newSettings = await got(settingsURL, {
@@ -111,7 +112,6 @@ class Launcher {
         }
 
         if (changed) {
-            this.state = States.STARTING
             this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
             pkg.dependencies = wantedDependencies
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -111,6 +111,7 @@ class Launcher {
         }
 
         if (changed) {
+            this.state = States.STARTING
             this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
             pkg.dependencies = wantedDependencies
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -10,6 +10,7 @@ const MAX_RESTART_COUNT = 5
 
 const States = {
     STOPPED: 'stopped',
+    INSTALLING: 'installing',
     STARTING: 'starting',
     RUNNING: 'running',
     SAFE: 'safe',
@@ -41,7 +42,6 @@ class Launcher {
     }
 
     async loadSettings () {
-        this.state = States.STARTING
         this.logBuffer.add({ level: 'system', msg: 'Loading project settings' })
         const settingsURL = `${this.options.forgeURL}/api/v1/projects/${this.options.project}/settings`
         const newSettings = await got(settingsURL, {
@@ -84,6 +84,7 @@ class Launcher {
     }
 
     async updatePackage () {
+        this.state = States.INSTALLING
         const pkgFilePath = path.join(this.settings.rootDir, this.settings.userDir, 'package.json')
         const packageContent = fs.readFileSync(pkgFilePath, { encoding: 'utf8' })
         const pkg = JSON.parse(packageContent)
@@ -185,7 +186,7 @@ class Launcher {
         if (!this.settings) {
             throw new Error('Failed to load settings')
         }
-        if (this.state === States.RUNNING) {
+        if (this.state === States.RUNNING || this.state === States.STARTING) {
             // Already running or starting - no need to start again
             return
         }


### PR DESCRIPTION
Set launcher in starting state while installing npm modules so the front end continues to poll state for new project or restarting

part of https://github.com/flowforge/flowforge/issues/990