### PR TITLE
Fix npm on windows

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -164,8 +164,8 @@ class Launcher {
             headers: {
                 authorization: 'Bearer ' + this.options.token
             }
-        // eslint-disable-next-line n/handle-callback-err
-        }).catch(err => {})
+        // eslint-disable-next-line node/handle-callback-err
+        }).catch(_err => {})
     }
 
     getState () {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -124,12 +124,12 @@ class Launcher {
             this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
             pkg.dependencies = wantedDependencies
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))
-
+            const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm'
             return new Promise((resolve, reject) => {
                 const child = childProcess.spawn(
-                    'npm',
+                    npmCommand,
                     ['install', '--production', '--no-audit', '--no-update-notifier', '--no-fund'],
-                    { cwd: path.join(this.settings.rootDir, this.settings.userDir) })
+                    { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir) })
                 child.stdout.on('data', (data) => {
                     this.logBuffer.add({ level: 'system', msg: '[npm] ' + data })
                 })

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -164,7 +164,6 @@ class Launcher {
             headers: {
                 authorization: 'Bearer ' + this.options.token
             }
-        // eslint-disable-next-line node/handle-callback-err
         }).catch(_err => {})
     }
 


### PR DESCRIPTION
fixes #77

NOTES
* uses `npm.cmd` on `win32`
* adds `windowsHide: true` to prevent terminal popup
* lint fixes

Tested on local env