### PR TITLE
Closes a timing window on slow starting systems

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -42,6 +42,7 @@ class Launcher {
     }
 
     async loadSettings () {
+        this.state = States.INSTALLING
         this.logBuffer.add({ level: 'system', msg: 'Loading project settings' })
         const settingsURL = `${this.options.forgeURL}/api/v1/projects/${this.options.project}/settings`
         let newSettings


### PR DESCRIPTION
It was possible to poll the launcher before it had downloaded the settings so reported "stopped" which meant the projects page would stop polling.

This sets state to "installing" as soon as `loadSettings()` is called.