### PR TITLE
Add settings for persistent storage

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -104,9 +104,26 @@ function getSettingsFile (settings) {
             broker: { ...settings.broker }
         }
     }
+    let contextStorage = ''
     if (settings.fileStore?.url) {
+        // file nodes settings
         projectSettings.fileStore = { ...settings.fileStore }
         projectSettings.fileStore.token ||= settings.projectToken
+        if (settings.licenseType === 'ee') {
+            // context storage settings
+            contextStorage = `contextStorage: {
+                default: "memory",
+                memory: { module: 'memory' },
+                persistent: {
+                    module: require("@flowforge/nr-persistent-context"),
+                    config: {
+                        projectID: '${settings.projectID}',
+                        url: '${settings.fileStore.url}',
+                        token: '${settings.projectToken}'
+                    }
+                }
+            },`
+        }
     }
     if (projectSettings.theme) {
         const themeSettings = {
@@ -122,6 +139,7 @@ function getSettingsFile (settings) {
     if (settings.nodesDir && settings.nodesDir.length) {
         nodesDir = `nodesDir: ${JSON.stringify(settings.nodesDir)},`
     }
+
     const settingsTemplate = `
 module.exports = {
     flowFile: 'flows.json',
@@ -148,6 +166,7 @@ module.exports = {
         baseURL: '${settings.storageURL}',
         token: '${settings.projectToken}'
     },
+    ${contextStorage}
     logging: {
         console: { level: 'info', metric: false, audit: false, handler: () => {
                 const levelNames = {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "@flowforge/nr-theme": "^0.1.3",
         "@flowforge/nr-project-nodes": "^0.1.1",
         "@flowforge/nr-file-nodes": "^0.0.2",
+        "@flowforge/nr-persistent-context": "^0.0.1",
         "body-parser": "^1.20.0",
         "command-line-args": "^5.2.1",
         "express": "^4.18.1",


### PR DESCRIPTION
part of https://github.com/flowforge/flowforge/issues/212

**NOTE** Requires `@flowforge/nr-persistent-context` to be pushed to NPM first

Adds below to `settings.js` if FORGE_STORAGE_URL is set and licence is "ee"

```js
{
    contextStorage: {
        default: "memory",
        memory: { module: 'memory' },
        persistent: {
            module: require("@flowforge/nr-persistent-context"),
            config: {
                projectID: '${settings.projectID}',
                url: '${settings.fileStore.url}',
                token: '${settings.projectToken}'
            }
        }
    },
}
```