### PR TITLE
Ensure allow/deny lists default to proper values

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -72,16 +72,16 @@ function getSettingsFile (settings) {
             projectSettings.modules.allowInstall = settings.settings.modules.allowInstall
         }
         if (settings.settings.palette?.allowList !== undefined) {
-            projectSettings.palette.allowList = settings.settings.palette.allowList
+            projectSettings.palette.allowList = settings.settings.palette.allowList || ['*']
         }
         if (settings.settings.palette?.denyList !== undefined) {
-            projectSettings.palette.denyList = settings.settings.palette.denyList
+            projectSettings.palette.denyList = settings.settings.palette.denyList || []
         }
         if (settings.settings.modules?.allowList !== undefined) {
-            projectSettings.modules.allowList = settings.settings.modules.allowList
+            projectSettings.modules.allowList = settings.settings.modules.allowList || ['*']
         }
         if (settings.settings.modules?.denyList !== undefined) {
-            projectSettings.modules.denyList = settings.settings.modules.denyList
+            projectSettings.modules.denyList = settings.settings.modules.denyList || []
         }
         if (settings.settings.httpNodeAuth?.user && settings.settings.httpNodeAuth?.pass) {
             projectSettings.httpNodeAuth = `httpNodeAuth: ${JSON.stringify(settings.settings.httpNodeAuth)},`


### PR DESCRIPTION
Fixes https://github.com/flowforge/flowforge/issues/1367

The newly introduced default template is setting `denyList` to a blank string. This was getting passed through as-is to the settings, which is interpreted by Node-RED as deny everything. That has been raised as an upstream issue - https://github.com/node-red/node-red/issues/3977

In the meantime, we should ensure we don't set a blank string in the settings file.