### PR TITLE
Add Team Library configuration settings

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -235,7 +235,21 @@ module.exports = {
         codeEditor: {
             lib: '${projectSettings.codeEditor}'
         },
-        tours: ${projectSettings.tours}
+        tours: ${projectSettings.tours},
+        library: {
+            sources: [
+                {
+                    id: "flowforge-team-library",
+                    type: "flowforge-team-library",
+                    label: "Team Library",
+                    icon: "font-awesome/fa-users",
+                    baseURL: '${settings.storageURL}',
+                    projectID: '${settings.projectID}',
+                    libraryID: '${settings.teamID}',
+                    token: '${settings.projectToken}'
+                }
+            ]
+        }
     },
     nodesExcludes: ${JSON.stringify(projectSettings.palette.nodesExcludes)},
     externalModules: {

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -27,7 +27,8 @@ function getSettingsFile (settings) {
         httpNodeMiddleware: '',
         tcpInAllowInboundConnections: '',
         udpInAllowInboundConnections: '',
-        tours: true
+        tours: true,
+        libraries: ''
     }
 
     if (settings.settings) {
@@ -149,6 +150,20 @@ function getSettingsFile (settings) {
         nodesDir = `nodesDir: ${JSON.stringify(settings.nodesDir)},`
     }
 
+    if (settings.licenseType === 'ee') {
+        const sharedLibraryConfig = {
+            id: 'flowforge-team-library',
+            type: 'flowforge-team-library',
+            label: 'Team Library',
+            icon: 'font-awesome/fa-users',
+            baseURL: settings.storageURL,
+            projectID: settings.projectID,
+            libraryID: settings.teamID,
+            token: settings.projectToken
+        }
+        projectSettings.libraries = `library: { sources: [ ${JSON.stringify(sharedLibraryConfig)} ] },`
+    }
+
     const settingsTemplate = `
 module.exports = {
     flowFile: 'flows.json',
@@ -235,21 +250,8 @@ module.exports = {
         codeEditor: {
             lib: '${projectSettings.codeEditor}'
         },
-        tours: ${projectSettings.tours},
-        library: {
-            sources: [
-                {
-                    id: "flowforge-team-library",
-                    type: "flowforge-team-library",
-                    label: "Team Library",
-                    icon: "font-awesome/fa-users",
-                    baseURL: '${settings.storageURL}',
-                    projectID: '${settings.projectID}',
-                    libraryID: '${settings.teamID}',
-                    token: '${settings.projectToken}'
-                }
-            ]
-        }
+        ${projectSettings.libraries}
+        tours: ${projectSettings.tours}
     },
     nodesExcludes: ${JSON.stringify(projectSettings.palette.nodesExcludes)},
     externalModules: {

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -152,7 +152,7 @@ describe('Runtime Settings', function () {
             settings.editorTheme.should.have.property('codeEditor')
             settings.editorTheme.codeEditor.should.have.property('lib', 'ace')
 
-            // Default should not have editorTheme.library as it is an EE feature
+            // Should have editorTheme.library as it is an EE feature
             settings.editorTheme.should.have.property('library')
 
             settings.should.have.property('nodesExcludes', ['abc', 'def'])

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -62,6 +62,9 @@ describe('Runtime Settings', function () {
             settings.externalModules.modules.should.have.property('allowList', ['*'])
             settings.should.have.property('functionExternalModules', true)
 
+            // Default should not have editorTheme.library as it is an EE feature
+            settings.editorTheme.should.not.have.property('library')
+
             settings.should.have.property('flowforge')
             settings.flowforge.should.have.property('forgeURL')
             settings.flowforge.should.have.property('teamID')
@@ -71,7 +74,7 @@ describe('Runtime Settings', function () {
             settings.should.not.have.property('httpNodeAuth')
             settings.should.not.have.property('httpNodeMiddleware')
         })
-        it('allows settings are set for the project', async function () {
+        it('includes ee-only settings when license applied', async function () {
             const result = runtimeSettings.getSettingsFile({
                 licenseType: 'ee',
                 credentialSecret: 'foo',
@@ -148,6 +151,9 @@ describe('Runtime Settings', function () {
             settings.editorTheme.logout.should.have.property('redirect')
             settings.editorTheme.should.have.property('codeEditor')
             settings.editorTheme.codeEditor.should.have.property('lib', 'ace')
+
+            // Default should not have editorTheme.library as it is an EE feature
+            settings.editorTheme.should.have.property('library')
 
             settings.should.have.property('nodesExcludes', ['abc', 'def'])
 


### PR DESCRIPTION
## Description

Adds a default Team Library to `settings.js` using the Library Store plugin provided by the `nr-storage` module via https://github.com/flowforge/flowforge-nr-storage/pull/27

## Related Issue(s)

Part of:
 - https://github.com/flowforge/flowforge/issues/237

Related PRs:
 - https://github.com/flowforge/flowforge-nr-storage/pull/27 - to add the Library Store plugin
 - https://github.com/flowforge/flowforge/pull/1529 - to add the Storage API routes


