### PR TITLE
Improve stuck intermediate state of project

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,8 @@ async function main () {
     try {
         await launcher.loadSettings()
         await launcher.start()
-    } catch (err) {
+    } catch (error) {
+        await launcher.logAuditEvent('start-failed', { error })
     }
 
     // const wss = new ws.Server({ clientTracking: false, noServer: true })

--- a/lib/admin.js
+++ b/lib/admin.js
@@ -50,7 +50,9 @@ class AdminInterface {
                     try {
                         await launcher.loadSettings()
                         await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
-                    } catch (err) {}
+                    } catch (error) {
+                        await launcher.logAuditEvent('start-failed', { error })
+                    }
                     response.send({})
                 }, 2000)
             } else if (request.body.cmd === 'start') {
@@ -60,7 +62,12 @@ class AdminInterface {
                     try {
                         await launcher.loadSettings()
                         await launcher.start(request.body.safe ? States.SAFE : States.RUNNING)
-                    } catch (err) {}
+                    } catch (error) {
+                        // delay error audit entry to allow the start command to return and be logged first
+                        setTimeout(() => {
+                            launcher?.logAuditEvent && launcher.logAuditEvent('start-failed', { error })
+                        }, 100)
+                    }
                     response.send({})
                 }
             } else if (request.body.cmd === 'logout') { // logout:nodered(step-4)

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -10,8 +10,8 @@ const MAX_RESTART_COUNT = 5
 
 const States = {
     STOPPED: 'stopped',
-    INSTALLING: 'installing',
     LOADING: 'loading',
+    INSTALLING: 'installing',
     STARTING: 'starting',
     RUNNING: 'running',
     SAFE: 'safe',

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -11,6 +11,7 @@ const MAX_RESTART_COUNT = 5
 const States = {
     STOPPED: 'stopped',
     INSTALLING: 'installing',
+    LOADING: 'loading',
     STARTING: 'starting',
     RUNNING: 'running',
     SAFE: 'safe',
@@ -42,7 +43,7 @@ class Launcher {
     }
 
     async loadSettings () {
-        this.state = States.INSTALLING
+        this.state = States.LOADING
         this.logBuffer.add({ level: 'system', msg: 'Loading project settings' })
         const settingsURL = `${this.options.forgeURL}/api/v1/projects/${this.options.project}/settings`
         let newSettings
@@ -53,9 +54,15 @@ class Launcher {
                 }
             }).json()
         } catch (err) {
+            this.settings = null
+            this.state = States.STOPPED
+            // if launcher failed to restart it will have old token
+            if (err?.response?.statusCode === 401) {
+                // throwing error will cause call to `start` to fail and an audit event will be logged
+                throw new Error('Unauthorized')
+            }
             // what to do when forge is down?
             console.log(`Unable to get settings from ${settingsURL} with error ${err.toString()}`)
-            this.settings = null
             return
         }
 
@@ -89,15 +96,25 @@ class Launcher {
 
         const settingsFileContent = getSettingsFile(this.settings)
         const settingsPath = path.join(this.settings.rootDir, this.settings.userDir, 'settings.js')
-        fs.writeFileSync(settingsPath, settingsFileContent)
-
-        await this.updatePackage()
         this.targetState = this.settings.state || States.RUNNING
+        try {
+            fs.writeFileSync(settingsPath, settingsFileContent)
+        } catch (error) {
+            this.state = States.STOPPED
+            this.logBuffer.add({ level: 'system', msg: 'Unable to write package file' })
+            throw error
+        }
+        try {
+            await this.updatePackage()
+        } catch (error) {
+            this.state = States.STOPPED
+            this.logBuffer.add({ level: 'system', msg: 'Unable to install or update packages' })
+            throw error
+        }
         this.logBuffer.add({ level: 'system', msg: `Target state is '${this.targetState}'` })
     }
 
     async updatePackage () {
-        this.state = States.INSTALLING
         const pkgFilePath = path.join(this.settings.rootDir, this.settings.userDir, 'package.json')
         const packageContent = fs.readFileSync(pkgFilePath, { encoding: 'utf8' })
         const pkg = JSON.parse(packageContent)
@@ -126,6 +143,7 @@ class Launcher {
         }
 
         if (changed) {
+            this.state = States.INSTALLING
             this.logBuffer.add({ level: 'system', msg: 'Updating project dependencies' })
             pkg.dependencies = wantedDependencies
             fs.writeFileSync(pkgFilePath, JSON.stringify(pkg, null, 2))

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -178,16 +178,27 @@ class Launcher {
         }
     }
 
-    async logAuditEvent (event) {
+    async logAuditEvent (event, body) {
+        const data = {
+            timestamp: Date.now(),
+            event
+        }
+        if (body && typeof body === 'object') {
+            if (body.error) {
+                data.error = {
+                    code: body.error.code || 'unexpected_error',
+                    error: body.error.error || body.error.message || 'Unexpected error'
+                }
+            }
+        }
         return got.post(this.options.forgeURL + '/logging/' + this.options.project + '/audit', {
-            json: {
-                timestamp: Date.now(),
-                event
-            },
+            json: data,
             headers: {
                 authorization: 'Bearer ' + this.options.token
             }
-        }).catch(_err => {})
+        }).catch(_err => {
+            console.error('Failed to log audit event', _err, event)
+        })
     }
 
     getState () {


### PR DESCRIPTION
## Description

* Add a new "loading" state to differentiate the launcher states "installing" and "starting"
   * This became necessary to determine where the startup (or start or restart) is failing
   * Prior to this, we "faked" the state "installing" even if we were not installing anything
* Ensure relevant info is passed to log and audit log
* Ensure audit log is always called for start failure
* Ensure launcher state is updated upon start failure (to prevent web page constant refresh)

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1232

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [-] Suitable unit/system level tests have been added and they pass
     - No test infrastructure in launcher for starting a project
 - [-] Documentation has been updated - NA
    - [-] Upgrade instructions - NA
    - [-] Configuration details - NA
    - [-] Concepts - NA

## Labels

 - [-] Backport needed? -> add the `backport` label - NA
 - [-] Includes a DB migration? -> add the `area:migration` label - NA

