### PR TITLE
Separate out Dashboard middleware handling

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -24,23 +24,44 @@ function getSettingsFile (settings) {
         fileStore: null,
         projectLink: null,
         httpNodeAuth: '',
+        setupAuthMiddleware: '',
         httpNodeMiddleware: '',
         tcpInAllowInboundConnections: '',
         udpInAllowInboundConnections: '',
         tours: true,
         libraries: ''
     }
-
+    let authMiddlewareRequired = false
     if (settings.settings) {
         // Template/project supplied settings
+        if (settings.settings.httpNodeAuth?.user && settings.settings.httpNodeAuth?.pass) {
+            projectSettings.httpNodeAuth = `httpNodeAuth: ${JSON.stringify(settings.settings.httpNodeAuth)},`
+        } else if (settings.settings.httpNodeAuth?.type === 'flowforge-user') {
+            authMiddlewareRequired = true
+            projectSettings.setupAuthMiddleware = `const flowforgeAuthMiddleware = require('@flowforge/nr-auth/middleware').init({
+    type: 'flowforge-user',
+    baseURL: '${settings.baseURL}',
+    forgeURL: '${settings.forgeURL}',
+    clientID: '${settings.clientID}',
+    clientSecret: '${settings.clientSecret}'
+})`
+            projectSettings.httpNodeMiddleware = `httpNodeMiddleware: flowforgeAuthMiddleware,`
+        }
         if (settings.credentialSecret !== undefined) {
             projectSettings.credentialSecret = `credentialSecret: '${settings.credentialSecret}',`
         }
         if (settings.settings.httpAdminRoot !== undefined) {
             projectSettings.httpAdminRoot = `httpAdminRoot: '${settings.settings.httpAdminRoot}',`
         }
-        if (settings.settings.dashboardUI !== undefined) {
-            projectSettings.dashboardUI = `ui: { path: '${settings.settings.dashboardUI}' },`
+        if (settings.settings.dashboardUI !== undefined || authMiddlewareRequired) {
+            const dashboardSettings = []
+            if (settings.settings.dashboardUI !== undefined) {
+                dashboardSettings.push(`path: '${settings.settings.dashboardUI}'`)
+            }
+            if (authMiddlewareRequired) {
+                dashboardSettings.push('middleware: flowforgeAuthMiddleware')
+            }
+            projectSettings.dashboardUI = `ui: { ${dashboardSettings.join(', ')}},`
         }
         if (settings.settings.disableEditor !== undefined) {
             projectSettings.disableEditor = `disableEditor: ${settings.settings.disableEditor},`
@@ -84,17 +105,6 @@ function getSettingsFile (settings) {
         }
         if (settings.settings.modules?.denyList !== undefined) {
             projectSettings.modules.denyList = settings.settings.modules.denyList || []
-        }
-        if (settings.settings.httpNodeAuth?.user && settings.settings.httpNodeAuth?.pass) {
-            projectSettings.httpNodeAuth = `httpNodeAuth: ${JSON.stringify(settings.settings.httpNodeAuth)},`
-        } else if (settings.settings.httpNodeAuth?.type === 'flowforge-user') {
-            projectSettings.httpNodeMiddleware = `httpNodeMiddleware: require('@flowforge/nr-auth/middleware').init({
-        type: 'flowforge-user',
-        baseURL: '${settings.baseURL}',
-        forgeURL: '${settings.forgeURL}',
-        clientID: '${settings.clientID}',
-        clientSecret: '${settings.clientSecret}'
-    }),`
         }
         if (settings.allowInboundTcp === true || settings.allowInboundTcp === false) {
             projectSettings.tcpInAllowInboundConnections = `tcpInAllowInboundConnections: ${settings.allowInboundTcp},`
@@ -165,6 +175,7 @@ function getSettingsFile (settings) {
     }
 
     const settingsTemplate = `
+${projectSettings.setupAuthMiddleware}
 module.exports = {
     flowFile: 'flows.json',
     flowFilePretty: true,

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -45,7 +45,7 @@ function getSettingsFile (settings) {
     clientID: '${settings.clientID}',
     clientSecret: '${settings.clientSecret}'
 })`
-            projectSettings.httpNodeMiddleware = `httpNodeMiddleware: flowforgeAuthMiddleware,`
+            projectSettings.httpNodeMiddleware = 'httpNodeMiddleware: flowforgeAuthMiddleware,'
         }
         if (settings.credentialSecret !== undefined) {
             projectSettings.credentialSecret = `credentialSecret: '${settings.credentialSecret}',`

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -249,7 +249,7 @@ describe('Runtime Settings', function () {
         settings.httpNodeAuth.should.eql({ user: 'fred', pass: 'secret' })
         settings.should.not.have.property('httpNodeMiddleware')
     })
-    it('includes httpNodeMiddle if flowforge-user auth type set', async function () {
+    it('includes httpNodeMiddleware if flowforge-user auth type set', async function () {
         const result = runtimeSettings.getSettingsFile({
             settings: {
                 httpNodeAuth: { type: 'flowforge-user' }
@@ -260,10 +260,34 @@ describe('Runtime Settings', function () {
             settings.should.not.have.property('httpNodeAuth')
             settings.should.have.property('httpNodeMiddleware')
             ;(typeof settings.httpNodeMiddleware).should.equal('function')
+            settings.should.have.property('ui')
+            settings.ui.should.not.have.property('path')
+            settings.ui.should.have.property('middleware')
+            ;(typeof settings.ui.middleware).should.equal('function')
         } catch (err) {
             // Temporary fix as this module will not be found when running in CI
             // until we publish the release of the new nr-auth module.
             err.toString().should.match(/Cannot find module '@flowforge\/nr-auth\/middleware'/)
         }
     })
+    it('includes httpNodeMiddleware if flowforge-user auth type set and dashboard ui set', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            settings: {
+                dashboardUI: '/foo',
+                httpNodeAuth: { type: 'flowforge-user' }
+            }
+        })
+        try {
+            const settings = await loadSettings(result)
+            settings.should.have.property('ui')
+            settings.ui.should.have.property('path', '/foo')
+            settings.ui.should.have.property('middleware')
+            ;(typeof settings.ui.middleware).should.equal('function')
+        } catch (err) {
+            // Temporary fix as this module will not be found when running in CI
+            // until we publish the release of the new nr-auth module.
+            err.toString().should.match(/Cannot find module '@flowforge\/nr-auth\/middleware'/)
+        }
+    })
+    
 })

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -289,5 +289,4 @@ describe('Runtime Settings', function () {
             err.toString().should.match(/Cannot find module '@flowforge\/nr-auth\/middleware'/)
         }
     })
-    
 })


### PR DESCRIPTION
## Description

The middleware added for FF Authentication of HTTP Routes has to be separately applied to dashboard.

In doing so, we have to change from using `req.path` to `req.originalUrl` as the mounted dashboard app strips off the mount point in `req.path` and we don't redirect back to the right place (this is via a separate PR in nr-auth)

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

