### PR TITLE
Allow Private CA Certs bundle to be passed to Node-RED

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -238,6 +238,10 @@ class Launcher {
             appEnv.NODE_RED_ENABLE_SAFE_MODE = true
         }
 
+        if (process.env.NODE_EXTRA_CA_CERTS) {
+            appEnv.NODE_EXTRA_CA_CERTS = process.env.NODE_EXTRA_CA_CERTS
+        }
+
         appEnv.NODE_PATH = [
             path.join(require.main.path, 'node_modules'),
             path.join(require.main.path, '..', '..')


### PR DESCRIPTION
## Description

If NODE_EXTRA_CA_CERTS environment variable present for the launcher then pass it's value through to Node-RED

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1525

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

