### PR TITLE
Improve crash loop detection

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -5,8 +5,18 @@ const childProcess = require('child_process')
 const LogBuffer = require('./logBuffer')
 const { getSettingsFile } = require('./runtimeSettings')
 
-const MIN_RESTART_TIME = 10000 // 10 seconds
+/** The point at which we check to see if we are in a boot loop */
 const MAX_RESTART_COUNT = 5
+
+/** The minimum run time we we expect when determining if we are in a boot loop
+ * - Run duration is measured from the time node-red is spawned to the time it crashes
+*/
+const MIN_RUNTIME = 30000
+
+/** If the distribution of run durations are less than this, we are likely in a boot loop
+ * - Run duration is measured from the time node-red is spawned to the time it crashes.
+*/
+const MIN_RUNTIME_DEVIATION = 2000 // 2 seconds either side of the mean
 
 const States = {
     STOPPED: 'stopped',
@@ -36,8 +46,11 @@ class Launcher {
             PATH: process.env.PATH
         }
         this.settings = null
-        this.startTime = []
-        this.restartCount = 0
+
+        // Array of times and run durations for monitoring boot loops
+        this.startTimes = []
+        this.runDurations = []
+
         this.logBuffer = new LogBuffer(this.options.logBufferMax || 1000)
         this.logBuffer.add({ level: 'system', msg: 'Launcher Started' })
     }
@@ -205,7 +218,7 @@ class Launcher {
     }
 
     getLastStartTime () {
-        return this.startTime.length !== 0 ? this.startTime[this.startTime.length - 1] : -1
+        return this.startTimes.length !== 0 ? this.startTimes[this.startTimes.length - 1] : -1
     }
 
     getLog () {
@@ -281,9 +294,9 @@ class Launcher {
         this.proc.on('spawn', () => {
             // only works at NodeJS 16+
             // this.proc.pid
-            this.startTime.push(Date.now())
-            if (this.startTime.length > MAX_RESTART_COUNT) {
-                this.startTime.shift()
+            this.startTimes.push(Date.now())
+            if (this.startTimes.length > MAX_RESTART_COUNT) {
+                this.startTimes.shift()
             }
         })
 
@@ -352,22 +365,32 @@ class Launcher {
                 this.state = States.CRASHED
                 await this.logAuditEvent('crashed')
 
-                if (this.startTime.length === MAX_RESTART_COUNT) {
-                    // check restart interval
-                    let avg = 0
-                    for (let i = this.startTime.length - 1; i > 0; i--) {
-                        avg += (this.startTime[i] - this.startTime[i - 1])
-                    }
-                    avg /= MAX_RESTART_COUNT
-                    if (avg < MIN_RESTART_TIME) {
-                        // restarting too fast - go to safe mode
-                        // reset the startTime list
-                        this.startTime = []
+                // log runtime duration
+                const lastStartTime = this.startTimes[this.startTimes.length - 1]
+                this.runDurations.push(Math.abs(Date.now() - lastStartTime))
+                if (this.runDurations.length > MAX_RESTART_COUNT) {
+                    this.runDurations.shift()
+                }
+
+                // if start count == MAX_RESTART_COUNT, then check for boot loop
+                if (this.startTimes.length === MAX_RESTART_COUNT) {
+                    // calculate the average runtime
+                    const avg = this.runDurations.reduce((a, b) => a + b, 0) / this.runDurations.length
+
+                    // calculate the mean deviation of runtime durations
+                    const meanDeviation = this.runDurations.reduce((a, b) => a + Math.abs(b - avg), 0) / this.runDurations.length
+
+                    // if the deviation is small (i.e. crashing at a consistent rate)
+                    // or the average runtime is low, then it is likely we in a boot loop
+                    if (meanDeviation < MIN_RUNTIME_DEVIATION || avg < MIN_RUNTIME) {
+                        // go to safe mode (or stop if already in safe mode)
+                        this.startTimes = []
+                        this.runDurations = []
                         if (this.targetState === States.SAFE) {
                             this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected whilst in safe mode. Stopping.' })
                             this.targetState = States.STOPPED
                         } else {
-                            this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Restarting in safe mode' })
+                            this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Restarting in safe mode.' })
                             this.targetState = States.SAFE
                             this.start()
                         }


### PR DESCRIPTION

## Description

### Improve crash loop detection

* Capture "Run Durations" (times from spawn to crash) alongside "Start Times"
* Use these to calculate mean deviation and average run duration
* Consider loop state if:
  - mean deviation of run durations is more or less than `x` (constant in code: `2` seconds)
  - average of run durations is less that `y` (constant in code: `30` seconds)

### Problem with the old version
The old version only considered time between starts of node-red. That could be affected by other things in the start up process.

### Logic and reasoning
* Capturing the Run duration (from spawn to crash) gives a more tightly focused measure
* Computing Mean Deviation means if the average startup time is GREATER than the MIN_START_TIME we can potentially still detect a crash loop since the point of an automatic crash will likely be very similar.


## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1579

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [-] Documentation has been updated
    - [-] Upgrade instructions
    - [-] Configuration details
    - [-] Concepts
 - [-] Changes `flowforge.yml`?
    - [-] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [-] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [-] Backport needed? -> add the `backport` label
 - [-] Includes a DB migration? -> add the `area:migration` label

