### PR TITLE
Resolve theme selection issue

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -69,8 +69,12 @@ function getSettingsFile (settings) {
         if (settings.settings.codeEditor) {
             projectSettings.codeEditor = settings.settings.codeEditor
         }
-        if (settings.settings.theme) {
-            projectSettings.theme = settings.settings.theme
+        if (typeof settings.settings.theme === 'string') {
+            if (settings.settings.theme === '' || settings.settings.theme === 'node-red') {
+                projectSettings.theme = '' // use default node-red theme
+            } else {
+                projectSettings.theme = settings.settings.theme
+            }
         }
         if (settings.settings.page?.title) {
             projectSettings.page_title = settings.settings.page.title

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -244,7 +244,7 @@ module.exports = {
         }
     },
     ${nodesDir}
-    ${projectSettings.themeSettings}
+    ${projectSettings.themeSettings || ''}
     editorTheme: {
         ${projectSettings.theme}
         page: {


### PR DESCRIPTION
## Description

As part of permitting [theme selection](https://github.com/flowforge/flowforge/issues/1816), an issue was discovered in the launcher should the theme value not be provided (i.e. when setting "no theme")

1. [dont write undefined to settings file if empty](https://github.com/flowforge/flowforge-nr-launcher/commit/4b284ad36d707c1eeb1f030cc0a79d4c9928af2a) 
   1. Prevents Node-RED startup failure if the theme is NOT set
2. [ensure theme only set if a value is provided](https://github.com/flowforge/flowforge-nr-launcher/commit/787b32f649506148cd9d3d791120892327cb3bbd)

## Related Issue(s)

https://github.com/flowforge/flowforge/issues/1816

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

