### PR TITLE
Ensure Node-RED process is stopped before attempting restart

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -18,6 +18,9 @@ const MIN_RUNTIME = 30000
 */
 const MIN_RUNTIME_DEVIATION = 2000 // 2 seconds either side of the mean
 
+/** How long wait for Node-RED to cleanly stop before killing */
+const NODE_RED_STOP_TIMEOUT = 10000
+
 const States = {
     STOPPED: 'stopped',
     LOADING: 'loading',
@@ -53,6 +56,10 @@ class Launcher {
 
         this.logBuffer = new LogBuffer(this.options.logBufferMax || 1000)
         this.logBuffer.add({ level: 'system', msg: 'Launcher Started' })
+
+        // A callback function that will be set if the launcher is waiting
+        // for Node-RED to exit
+        this.exitCallback = null
     }
 
     async loadSettings () {
@@ -365,41 +372,47 @@ class Launcher {
                 this.state = States.CRASHED
                 await this.logAuditEvent('crashed')
 
-                // log runtime duration
-                const lastStartTime = this.startTimes[this.startTimes.length - 1]
-                this.runDurations.push(Math.abs(Date.now() - lastStartTime))
-                if (this.runDurations.length > MAX_RESTART_COUNT) {
-                    this.runDurations.shift()
-                }
+                // Only restart if our target state is not stopped
+                if (this.targetState !== States.STOPPED) {
+                    // log runtime duration
+                    const lastStartTime = this.startTimes[this.startTimes.length - 1]
+                    this.runDurations.push(Math.abs(Date.now() - lastStartTime))
+                    if (this.runDurations.length > MAX_RESTART_COUNT) {
+                        this.runDurations.shift()
+                    }
 
-                // if start count == MAX_RESTART_COUNT, then check for boot loop
-                if (this.startTimes.length === MAX_RESTART_COUNT) {
-                    // calculate the average runtime
-                    const avg = this.runDurations.reduce((a, b) => a + b, 0) / this.runDurations.length
+                    // if start count == MAX_RESTART_COUNT, then check for boot loop
+                    if (this.startTimes.length === MAX_RESTART_COUNT) {
+                        // calculate the average runtime
+                        const avg = this.runDurations.reduce((a, b) => a + b, 0) / this.runDurations.length
 
-                    // calculate the mean deviation of runtime durations
-                    const meanDeviation = this.runDurations.reduce((a, b) => a + Math.abs(b - avg), 0) / this.runDurations.length
+                        // calculate the mean deviation of runtime durations
+                        const meanDeviation = this.runDurations.reduce((a, b) => a + Math.abs(b - avg), 0) / this.runDurations.length
 
-                    // if the deviation is small (i.e. crashing at a consistent rate)
-                    // or the average runtime is low, then it is likely we in a boot loop
-                    if (meanDeviation < MIN_RUNTIME_DEVIATION || avg < MIN_RUNTIME) {
-                        // go to safe mode (or stop if already in safe mode)
-                        this.startTimes = []
-                        this.runDurations = []
-                        if (this.targetState === States.SAFE) {
-                            this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected whilst in safe mode. Stopping.' })
-                            this.targetState = States.STOPPED
+                        // if the deviation is small (i.e. crashing at a consistent rate)
+                        // or the average runtime is low, then it is likely we in a boot loop
+                        if (meanDeviation < MIN_RUNTIME_DEVIATION || avg < MIN_RUNTIME) {
+                            // go to safe mode (or stop if already in safe mode)
+                            this.startTimes = []
+                            this.runDurations = []
+                            if (this.targetState === States.SAFE) {
+                                this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected whilst in safe mode. Stopping.' })
+                                this.targetState = States.STOPPED
+                            } else {
+                                this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Restarting in safe mode.' })
+                                this.targetState = States.SAFE
+                                this.start()
+                            }
                         } else {
-                            this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Restarting in safe mode.' })
-                            this.targetState = States.SAFE
                             this.start()
                         }
                     } else {
                         this.start()
                     }
-                } else {
-                    this.start()
                 }
+            }
+            if (this.exitCallback) {
+                this.exitCallback()
             }
         })
 
@@ -438,12 +451,38 @@ class Launcher {
     async stop () {
         this.logBuffer.add({ level: 'system', msg: 'Stopping Node-RED' })
         this.targetState = States.STOPPED
+        if (this.deferredStop) {
+            // A stop request is already inflight - return the existing deferred object
+            return this.deferredStop()
+        }
         if (this.proc) {
-            this.state = States.STOPPED
-            this.proc.kill()
-            // TODO: block until proc has actually stopped
-            this.proc.unref()
-            this.proc = undefined
+            // Setup a promise that will resolve once the process has really exited
+            this.deferredStop = new Promise((resolve, reject) => {
+                // Setup a timeout so we can more forcefully kill Node-RED
+                // if it has hung
+                this.exitTimeout = setTimeout(() => {
+                    this.logBuffer.add({ level: 'system', msg: 'Node-RED stop timed-out - sending SIGKILL' })
+                    if (this.proc) {
+                        this.proc.kill('SIGKILL')
+                    }
+                }, NODE_RED_STOP_TIMEOUT)
+                // Setup a callback for when the process has actually exited
+                this.exitCallback = () => {
+                    clearTimeout(this.exitTimeout)
+                    this.exitCallback = null
+                    this.deferredStop = null
+                    this.exitTimeout = null
+                    this.proc.unref()
+                    this.proc = undefined
+                    resolve()
+                }
+                // Send a kill signal. On Linux this will be a SIGTERM and
+                // allow Node-RED to shutdown cleanly. Windows looks like it does
+                // it more forcefully by default.
+                this.proc.kill()
+                this.state = States.STOPPED
+            })
+            return this.deferredStop
         } else {
             this.state = States.STOPPED
         }

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -453,7 +453,7 @@ class Launcher {
         this.targetState = States.STOPPED
         if (this.deferredStop) {
             // A stop request is already inflight - return the existing deferred object
-            return this.deferredStop()
+            return this.deferredStop
         }
         if (this.proc) {
             // Setup a promise that will resolve once the process has really exited


### PR DESCRIPTION
Part of #110 

## Description

When asking the launcher to restart Node-RED it would send the kill signal, wait two seconds then start Node-RED.

This could lead to errors if the shutdown took longer than expected as it would start a second NR process that then fails because the port is still in use. A slow shutdown could be caused by a node is tidying up some state, or the flows being stuck in a hard loop (`while(true){}` in a Function node).

This fix improves the shutdown logic so that:

 1. The promise returned by `Launcher.stop()` doesn't resolve until the Node-RED process has actually stopped
 2. After the initial shutdown request (SIGTERM), if Node-RED is still running after 10s, it sends a SIGKILL

Whilst we don't expose `stop` the end user, I did also observe the existing behaviour would mean if Node-RED crashed whilst stopped it would get restarted - even if it was a requested stop.

I have tested this against the following conditions:

1. A node takes too long to close itself
2. A node triggers a process.exit(1) - ie unexpected shutdown
3. A flow with `while(true){}` in causing a completely unresponsive editor

This doesn't address all of #110 - just the part around ensuring we can restart when NR is hung. The next task (and next PR) is to add logic to detect the runtime being hung.


## Related Issue(s)


## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? --> - **No** - we don't have UT coverage for this part of the launcher as it involves managing external Node-RED processes. This is existing technical debt.
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

