### PR TITLE
Detect hung node-red via regularly polling

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -318,6 +318,9 @@ class Launcher {
             }
         })
 
+        /**
+         * Performs an HTTP HEAD to the baseURL of Node-RED to check its liveness.
+         */
         const statusPoll = async () => {
             if (this.targetState === States.STOPPED) {
                 return States.STOPPED
@@ -344,6 +347,13 @@ class Launcher {
             throw new Error()
         }
 
+        /**
+         * Called after Node-RED exits unexpectedly. It calculates the runtime
+         * duration and decides if we've detected a crash loop.
+         * If a loop is detected, restarts in safe mode.
+         * If a loop is detected and we're already in safe mode, stops Node-RED
+         * Otherwise, restarts normally
+         */
         const restartAfterUnexpectedExit = async () => {
             const lastStartTime = this.startTimes[this.startTimes.length - 1]
             const duration = Math.abs(Date.now() - lastStartTime)

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -401,7 +401,7 @@ class Launcher {
         this.healthPoll = setInterval(() => {
             if (this.state === States.STARTING || this.state === States.RUNNING) {
                 statusPoll().then(() => {
-                    // A healthly result
+                    // A healthy result
                     errorCount = 0
                     if (this.state === States.STARTING) {
                         this.state = States.RUNNING
@@ -409,7 +409,7 @@ class Launcher {
                 }).catch(async _ => {
                     // Error polling Node-RED settings page
                     errorCount++
-                    if (errorCount === 2) {
+                    if (errorCount === HEALTH_POLL_MAX_ERROR_COUNT) {
                         this.logBuffer.add({ level: 'system', msg: 'Node-RED hang detected.' })
                         const targetState = this.state
 

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -22,10 +22,14 @@ const MIN_RUNTIME_DEVIATION = 2000 // 2 seconds either side of the mean
 const NODE_RED_STOP_TIMEOUT = 10000
 
 /** Interval between status polls of Node-RED used to detect a hung runtime */
-const HEALTH_POLL_INTERVAL = 10000
+/** Interval between status polls of Node-RED used to detect a hung runtime */
+const HEALTH_POLL_INTERVAL = 7499 // A prime number (to minimise syncing with other processes)
 
 /** Timeout to apply to health polling requests */
-const HEALTH_POLL_TIMEOUT = 100
+const HEALTH_POLL_TIMEOUT = HEALTH_POLL_INTERVAL - 500 // Allow 500ms to avoid overlapping requests
+
+/** The number of consecutive timeouts before considering a NR hang */
+const HEALTH_POLL_MAX_ERROR_COUNT = 3
 
 const States = {
     STOPPED: 'stopped',

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -21,6 +21,12 @@ const MIN_RUNTIME_DEVIATION = 2000 // 2 seconds either side of the mean
 /** How long wait for Node-RED to cleanly stop before killing */
 const NODE_RED_STOP_TIMEOUT = 10000
 
+/** Interval between status polls of Node-RED used to detect a hung runtime */
+const HEALTH_POLL_INTERVAL = 10000
+
+/** Timeout to apply to health polling requests */
+const HEALTH_POLL_TIMEOUT = 100
+
 const States = {
     STOPPED: 'stopped',
     LOADING: 'loading',
@@ -60,6 +66,8 @@ class Launcher {
         // A callback function that will be set if the launcher is waiting
         // for Node-RED to exit
         this.exitCallback = null
+
+        this.healthPoll = null
     }
 
     async loadSettings () {
@@ -237,6 +245,9 @@ class Launcher {
     }
 
     async start (targetState) {
+        if (this.deferredStop) {
+            await this.deferredStop()
+        }
         if (targetState) {
             this.targetState = targetState
         }
@@ -309,10 +320,7 @@ class Launcher {
 
         const statusPoll = async () => {
             if (this.targetState === States.STOPPED) {
-                return Promise.resolve(States.STOPPED)
-            }
-            if (this.state !== States.STARTING) {
-                return Promise.resolve(this.state)
+                return States.STOPPED
             }
             let statusCode = 0
             try {
@@ -321,38 +329,90 @@ class Launcher {
                         pragma: 'no-cache',
                         'Cache-Control': 'max-age=0, must-revalidate, no-cache'
                     },
-                    timeout: { request: 500 },
+                    timeout: { request: HEALTH_POLL_TIMEOUT },
                     retry: { limit: 0 }
                 }
-                const res = await got.get(this.settings.baseURL, opts)
+                // Use a HEAD request to minimise data transfer
+                const res = await got.head(this.settings.baseURL, opts)
                 statusCode = res.statusCode || 500
             } catch (error) {
                 statusCode = error.response?.statusCode || 500
             }
             if (statusCode >= 200 && statusCode < 500) {
-                return Promise.resolve(States.RUNNING)
+                return States.RUNNING
             }
-            return Promise.reject(new Error())
+            throw new Error()
         }
 
-        setTimeout((_launcher) => {
-            // Make 15 attempts to get good response from node-red
-            //   over 3min, starting with 5s delays, ramping up to
-            //   16s starting from the 3rd retry apply a factor of
-            //   1.28 for each back off
-            // 1st TRY     :  delay 5s
-            // RETRY       :  1   2   3   4   5   6   ...  13    14
-            // DELAY (sec) :  5   5   6   8   10  13  ...  16    16
-            // TOTAL DELAY :  10  15  21  29  39  52  ...  164   180
-            promiseWithRetry(statusPoll, 14, 5000, 16000, 3, 1.28, 0.02)
-                .then(status => {
-                    _launcher.state = status
-                }).catch(() => {
-                    if (_launcher.isHealthy()) {
-                        _launcher.state = States.RUNNING
+        const restartAfterUnexpectedExit = async () => {
+            const lastStartTime = this.startTimes[this.startTimes.length - 1]
+            const duration = Math.abs(Date.now() - lastStartTime)
+            this.runDurations.push(duration)
+            if (this.runDurations.length > MAX_RESTART_COUNT) {
+                this.runDurations.shift()
+            }
+
+            this.logBuffer.add({ level: 'system', msg: `Node-RED unexpectedly stopped after: ${Math.round(duration / 1000)}s` })
+
+            // if start count == MAX_RESTART_COUNT, then check for boot loop
+            if (this.startTimes.length === MAX_RESTART_COUNT) {
+                // calculate the average runtime
+                const avg = this.runDurations.reduce((a, b) => a + b, 0) / this.runDurations.length
+
+                // calculate the mean deviation of runtime durations
+                const meanDeviation = this.runDurations.reduce((a, b) => a + Math.abs(b - avg), 0) / this.runDurations.length
+
+                // if the deviation is small (i.e. crashing at a consistent rate)
+                // or the average runtime is low, then it is likely we in a boot loop
+                if (meanDeviation < MIN_RUNTIME_DEVIATION || avg < MIN_RUNTIME) {
+                    // go to safe mode (or stop if already in safe mode)
+                    this.startTimes = []
+                    this.runDurations = []
+                    if (this.targetState === States.SAFE) {
+                        this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected whilst in safe mode. Stopping.' })
+                        this.targetState = States.STOPPED
+                    } else {
+                        this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Restarting in safe mode.' })
+                        this.targetState = States.SAFE
+                        this.start()
+                    }
+                } else {
+                    this.start()
+                }
+            } else {
+                this.start()
+            }
+        }
+
+        if (this.healthPoll) {
+            clearInterval(this.healthPoll)
+        }
+        let errorCount = 0
+        this.healthPoll = setInterval(() => {
+            if (this.state === States.STARTING || this.state === States.RUNNING) {
+                statusPoll().then(() => {
+                    // A healthly result
+                    errorCount = 0
+                    if (this.state === States.STARTING) {
+                        this.state = States.RUNNING
+                    }
+                }).catch(async _ => {
+                    // Error polling Node-RED settings page
+                    errorCount++
+                    if (errorCount === 2) {
+                        this.logBuffer.add({ level: 'system', msg: 'Node-RED hang detected.' })
+                        const targetState = this.state
+
+                        // Calling stop will clear the health poll interval
+                        await this.stop()
+                        this.targetState = targetState
+                        // Restart via restartAfterUnexpectedExit as it will check
+                        // for a restart loop
+                        restartAfterUnexpectedExit()
                     }
                 })
-        }, 100, this)
+            }
+        }, HEALTH_POLL_INTERVAL)
 
         this.proc.on('close', (code, signal) => {
             // console.log("node-red closed with", {code,signal})
@@ -374,41 +434,7 @@ class Launcher {
 
                 // Only restart if our target state is not stopped
                 if (this.targetState !== States.STOPPED) {
-                    // log runtime duration
-                    const lastStartTime = this.startTimes[this.startTimes.length - 1]
-                    this.runDurations.push(Math.abs(Date.now() - lastStartTime))
-                    if (this.runDurations.length > MAX_RESTART_COUNT) {
-                        this.runDurations.shift()
-                    }
-
-                    // if start count == MAX_RESTART_COUNT, then check for boot loop
-                    if (this.startTimes.length === MAX_RESTART_COUNT) {
-                        // calculate the average runtime
-                        const avg = this.runDurations.reduce((a, b) => a + b, 0) / this.runDurations.length
-
-                        // calculate the mean deviation of runtime durations
-                        const meanDeviation = this.runDurations.reduce((a, b) => a + Math.abs(b - avg), 0) / this.runDurations.length
-
-                        // if the deviation is small (i.e. crashing at a consistent rate)
-                        // or the average runtime is low, then it is likely we in a boot loop
-                        if (meanDeviation < MIN_RUNTIME_DEVIATION || avg < MIN_RUNTIME) {
-                            // go to safe mode (or stop if already in safe mode)
-                            this.startTimes = []
-                            this.runDurations = []
-                            if (this.targetState === States.SAFE) {
-                                this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected whilst in safe mode. Stopping.' })
-                                this.targetState = States.STOPPED
-                            } else {
-                                this.logBuffer.add({ level: 'system', msg: 'Node-RED restart loop detected. Restarting in safe mode.' })
-                                this.targetState = States.SAFE
-                                this.start()
-                            }
-                        } else {
-                            this.start()
-                        }
-                    } else {
-                        this.start()
-                    }
+                    restartAfterUnexpectedExit()
                 }
             }
             if (this.exitCallback) {
@@ -450,6 +476,9 @@ class Launcher {
 
     async stop () {
         this.logBuffer.add({ level: 'system', msg: 'Stopping Node-RED' })
+        // Stop the health poll - do not want to mistake a stopping/stopped Node-RED
+        // for an unhealthly one
+        clearInterval(this.healthPoll)
         this.targetState = States.STOPPED
         if (this.deferredStop) {
             // A stop request is already inflight - return the existing deferred object
@@ -461,7 +490,7 @@ class Launcher {
                 // Setup a timeout so we can more forcefully kill Node-RED
                 // if it has hung
                 this.exitTimeout = setTimeout(() => {
-                    this.logBuffer.add({ level: 'system', msg: 'Node-RED stop timed-out - sending SIGKILL' })
+                    this.logBuffer.add({ level: 'system', msg: 'Node-RED stop timed-out. Sending SIGKILL' })
                     if (this.proc) {
                         this.proc.kill('SIGKILL')
                     }
@@ -510,68 +539,6 @@ class Launcher {
             this.logBuffer.add({ level: 'system', msg: `Error logging out Node-RED: ${error.toString()}` })
         }
     }
-}
-
-/**
- * Async wait
- * @param {number} milliseconds How long to wait before yielding
- */
-function wait (milliseconds) {
-    return new Promise((resolve) => setTimeout(resolve, milliseconds))
-}
-
-/**
- * Returns a value with the percentage of jitter specified
- * @param {Number} [value = 1]  The value to jitter
- * @param {Number} [jitter = 0.01]  Percentage of jitter to apply (i.e. 0.01 = 1%,  1 = 100%)
- * @return {Number} The input value with jitter applied
- */
-function jitter (value, jitter = 0.01) {
-    const max = value * (1 + jitter)
-    const min = value * (1 - jitter)
-    return Math.floor(Math.random() * (max - min)) + min
-}
-
-/**
- * Execute a promise and retry with custom back-off and jitter
- * @param {Promise} promise promise to be executed
- * @param {number} [maxRetries] The maximum number of retries to be attempted  (defaults to 2)
- * @param {number} [delay] The initial ms delay (defaults to 1000ms)
- * @param {number} [maxDelay] The maximum ms delay after back-off (defaults to unlimited)
- * @param {number} [backOffAt] The retry number to start ramping the delay (defaults to 0)
- * @param {number} [factor] The delay increase factor. A value of 2 would effectively double the delay with each retry (defaults to 2)
- * @param {number} [jitterPercent] The percentage of jitter to apply (defaults to 0.02 [2%])
- * @returns {Promise} The result of the given promise passed in
- */
-function promiseWithRetry (promise, maxRetries, delay, maxDelay, backOffAt, factor, jitterPercent) {
-    // sanitise defaults
-    maxRetries = maxRetries == null ? 2 : Math.max(maxRetries, 0)
-    delay = delay == null ? 1000 : Math.max(delay, 1)
-    maxDelay = maxDelay == null ? 0 : Math.max(maxDelay, 0)
-    backOffAt = backOffAt == null ? 0 : Math.max(backOffAt, 0)
-    factor = factor == null ? 2 : Math.max(factor, 0.1)
-    jitterPercent = jitterPercent == null ? 0.02 : Math.max(jitterPercent, 0)
-    let waitTime = delay // initial delay
-    let backOffCount = 0
-    async function _execPromise (retryNo) {
-        try {
-            if (retryNo && retryNo >= backOffAt) {
-                waitTime = parseInt(factor ** ++backOffCount * delay)
-                if (maxDelay && waitTime > maxDelay) {
-                    waitTime = maxDelay
-                }
-            }
-            const _waitTime = parseInt(jitter(waitTime, jitterPercent)) // add jitter
-            await wait(_waitTime)
-            return await promise()
-        } catch (e) {
-            if (retryNo < maxRetries) {
-                return _execPromise(retryNo + 1)
-            }
-            throw e
-        }
-    }
-    return _execPromise(0)
 }
 
 module.exports = { Launcher, States }


### PR DESCRIPTION
Closes #110 

## Description

This is a follow up to #111 .

It changes the polling done by the launcher to monitor Node-RED.

 - The polling now uses `HTTP HEAD` rather than `GET` to avoid unnecessary network traffic
 - It polls every 10s from the point we start the Node-RED process.
 - If it gets two consecutive errors from the poll, it considers the instance to have hung - and triggers a restart
 - The 'restart loop' logic has been refactored so it can be reused for the hang scenario as well as the existing crash loop handling.

With the current chosen timings, it will take approx 30s to detect and restart a hung Node-RED (two 10s poll intervals to confirm the hang, then 10s timeout waiting for NR to stop before we force kill and restart). We may need to tune these timings - but these values feel an okay starting point that will avoid accidentally killing a Node-RED instance that is temporarily overloaded.

I have tested this with a Function node containing `while(true) {}` that locks up the node.js event loop in two scenarios:

1. allowing NR to start up properly then manually triggering the Function node
    - the hang is detected and Node-RED is restarted
2. triggering the function node automatically on start
    - the hang is detected, NR restarted, it hangs again... after 5 restarts the hang loop is detected and it restarts in safe mode


## Related Issue(s)

#110 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

