### PR TITLE
Allow more failed pings during startup to avoid slow starts getting killed

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -28,6 +28,9 @@ const HEALTH_POLL_INTERVAL = 7499 // A prime number (to minimise syncing with ot
 /** Timeout to apply to health polling requests */
 const HEALTH_POLL_TIMEOUT = HEALTH_POLL_INTERVAL - 500 // Allow 500ms to avoid overlapping requests
 
+/** The number of consecutive timeouts during startup phase before considering a NR hang */
+const HEALTH_POLL_MAX_STARTUP_ERROR_COUNT = 5
+
 /** The number of consecutive timeouts before considering a NR hang */
 const HEALTH_POLL_MAX_ERROR_COUNT = 3
 
@@ -413,7 +416,8 @@ class Launcher {
                 }).catch(async _ => {
                     // Error polling Node-RED settings page
                     errorCount++
-                    if (errorCount === HEALTH_POLL_MAX_ERROR_COUNT) {
+                    if ((this.state === States.STARTING && errorCount === HEALTH_POLL_MAX_STARTUP_ERROR_COUNT) ||
+                        (this.state === States.RUNNING && errorCount === HEALTH_POLL_MAX_ERROR_COUNT)) {
                         this.logBuffer.add({ level: 'system', msg: 'Node-RED hang detected.' })
                         const targetState = this.state
 


### PR DESCRIPTION
Node-RED may be slow to start, which can cause a false-positive on the hang detection.

This PR gives it a two more poll cycles during the startup phase.