### PR TITLE
Increase number of startup polls allowed to fail for hang detection

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -29,7 +29,7 @@ const HEALTH_POLL_INTERVAL = 7499 // A prime number (to minimise syncing with ot
 const HEALTH_POLL_TIMEOUT = HEALTH_POLL_INTERVAL - 500 // Allow 500ms to avoid overlapping requests
 
 /** The number of consecutive timeouts during startup phase before considering a NR hang */
-const HEALTH_POLL_MAX_STARTUP_ERROR_COUNT = 5
+const HEALTH_POLL_MAX_STARTUP_ERROR_COUNT = 10
 
 /** The number of consecutive timeouts before considering a NR hang */
 const HEALTH_POLL_MAX_ERROR_COUNT = 3


### PR DESCRIPTION
The current value gives Node-RED 37s to start up. We have seen instances when running on slow hardware this isn't quite enough.

This PR doubles the timeout to 75s (10 x 7.5s interval polls). This balances the need to detect a hung node-red in a timely manner vs not letting node-red start at all!
