### PR TITLE
Ensure HOME env var set if present

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -280,6 +280,10 @@ class Launcher {
             appEnv.NODE_EXTRA_CA_CERTS = process.env.NODE_EXTRA_CA_CERTS
         }
 
+        if (process.env.HOME) {
+            appEnv.HOME = process.env.HOME
+        }
+
         appEnv.NODE_PATH = [
             path.join(require.main.path, 'node_modules'),
             path.join(require.main.path, '..', '..')


### PR DESCRIPTION
fixes #117

## Description

<!-- Describe your changes in detail -->
The `HOME` environment variable is not being copied to the Node-RED process

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#117 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

