### PR TITLE
Make NR listen on IPv6 as well as IPv4

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -181,6 +181,7 @@ function getSettingsFile (settings) {
     const settingsTemplate = `
 ${projectSettings.setupAuthMiddleware}
 module.exports = {
+    uiHost: '::',
     flowFile: 'flows.json',
     flowFilePretty: true,
     adminAuth: require('@flowforge/nr-launcher/adminAuth')({


### PR DESCRIPTION
fixes flowforge/flowforge#2202

## Description

<!-- Describe your changes in detail -->
Force Node-RED to listen on IPv6 as well as IPv4

## Related Issue(s)

<!-- What issue does this PR relate to? -->
flowforge/flowforge#2202

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

