### PR TITLE
Set IPv4 first flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,12 @@ const fs = require('fs')
 const path = require('path')
 const commandLineArgs = require('command-line-args')
 
+const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+if (NODE_MAJOR_VERSION > 14) {
+    const dns = require('node:dns')
+    dns.setDefaultResultOrder('ipv4first')
+}
+
 const { Launcher } = require('./lib/launcher')
 const { AdminInterface } = require('./lib/admin')
 

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fs = require('fs')
 const path = require('path')
 const commandLineArgs = require('command-line-args')
 
-const NODE_MAJOR_VERSION = process.versions.node.split('.')[0];
+const NODE_MAJOR_VERSION = process.versions.node.split('.')[0]
 if (NODE_MAJOR_VERSION > 14) {
     const dns = require('node:dns')
     dns.setDefaultResultOrder('ipv4first')

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -181,7 +181,6 @@ function getSettingsFile (settings) {
     const settingsTemplate = `
 ${projectSettings.setupAuthMiddleware}
 module.exports = {
-    uiHost: '::',
     flowFile: 'flows.json',
     flowFilePretty: true,
     adminAuth: require('@flowforge/nr-launcher/adminAuth')({


### PR DESCRIPTION
fixes flowforge/flowforge#2202

## Description

<!-- Describe your changes in detail -->
revert listening on IPv6 and IPv4 and make DNS use IPv4 first.

This makes the nr-launcher match Node-RED's behaviour.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
flowforge/flowforge#2202

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

