### PR TITLE
Disable the editor if HA enabled

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -66,7 +66,7 @@ function getSettingsFile (settings) {
         if (settings.settings.disableEditor !== undefined) {
             projectSettings.disableEditor = `disableEditor: ${settings.settings.disableEditor},`
         }
-        if (settings.settings.ha?.replicas === 2) {
+        if (settings.settings.ha?.replicas >= 2) {
             projectSettings.disableEditor = 'disableEditor: true'
         }
         if (settings.settings.codeEditor) {

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -66,6 +66,9 @@ function getSettingsFile (settings) {
         if (settings.settings.disableEditor !== undefined) {
             projectSettings.disableEditor = `disableEditor: ${settings.settings.disableEditor},`
         }
+        if (settings.settings.ha?.replicas === 2) {
+            projectSettings.disableEditor = 'disableEditor: true'
+        }
         if (settings.settings.codeEditor) {
             projectSettings.codeEditor = settings.settings.codeEditor
         }

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -293,4 +293,15 @@ describe('Runtime Settings', function () {
             err.toString().should.match(/Cannot find module '@flowforge\/nr-auth\/middleware'/)
         }
     })
+    it('test HA settings disable editor', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            settings: {
+                ha: {
+                    replicas: 2
+                }
+            }
+        })
+        const settings = await loadSettings(result)
+        settings.should.have.property('disableEditor', true)
+    })
 })


### PR DESCRIPTION
part of #121

## Description
Disable the editor if settings.ha.replica > 2

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

