### PR TITLE
Pass HA flag to project nodes if enabled

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -130,6 +130,9 @@ function getSettingsFile (settings) {
             token: settings.projectToken,
             broker: { ...settings.broker }
         }
+        if (settings.settings.ha?.replicas >= 2) {
+            projectSettings.projectLink.useSharedSubscriptions = true
+        }
     }
     let contextStorage = ''
     if (settings.fileStore?.url) {

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -186,6 +186,7 @@ describe('Runtime Settings', function () {
             settings.flowforge.projectLink.broker.should.have.property('url', 'BROKERURL')
             settings.flowforge.projectLink.broker.should.have.property('username', 'BROKERUSERNAME')
             settings.flowforge.projectLink.broker.should.have.property('password', 'BROKERPASSWORD')
+            settings.flowforge.projectLink.should.not.have.property('useSharedSubscriptions')
         })
         it('does not include projectLink if licenseType not ee', async function () {
             const result = runtimeSettings.getSettingsFile({
@@ -293,8 +294,14 @@ describe('Runtime Settings', function () {
             err.toString().should.match(/Cannot find module '@flowforge\/nr-auth\/middleware'/)
         }
     })
-    it('test HA settings disable editor', async function () {
+    it('includes HA settings when enabled', async function () {
         const result = runtimeSettings.getSettingsFile({
+            licenseType: 'ee',
+            broker: {
+                url: 'BROKERURL',
+                username: 'BROKERUSERNAME',
+                password: 'BROKERPASSWORD'
+            },
             settings: {
                 ha: {
                     replicas: 2
@@ -303,5 +310,7 @@ describe('Runtime Settings', function () {
         })
         const settings = await loadSettings(result)
         settings.should.have.property('disableEditor', true)
+        settings.flowforge.should.have.property('projectLink')
+        settings.flowforge.projectLink.should.have.property('useSharedSubscriptions', true)
     })
 })


### PR DESCRIPTION
Part of https://github.com/flowforge/flowforge/issues/2156
## Description

The project nodes need to know whether to use shared subscriptions or not based on whether the instance is HA enabled or not.

This sets the `useSharedSubscriptions` flag as needed.

## Related Issue(s)



## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

