### PR TITLE
Update health poll to use 127.0.0.1 address

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -336,6 +336,12 @@ class Launcher {
             if (this.targetState === States.STOPPED) {
                 return States.STOPPED
             }
+            const parsedUrl = new URL(this.settings.baseURL)
+            parsedUrl.protocol = 'http:'
+            parsedUrl.host = '127.0.0.1'
+            parsedUrl.port = this.settings.port
+            const pollUrl = parsedUrl.toString()
+
             let statusCode = 0
             try {
                 const opts = {
@@ -347,10 +353,11 @@ class Launcher {
                     retry: { limit: 0 }
                 }
                 // Use a HEAD request to minimise data transfer
-                const res = await got.head(this.settings.baseURL, opts)
+                const res = await got.head(pollUrl, opts)
                 statusCode = res.statusCode || 500
             } catch (error) {
-                console.log('Failed to poll NR on ', this.settings.baseURL, error)
+                this.logBuffer.add({ level: 'system', msg: `Node-RED health check failed: ${error.toString()} (${pollUrl})` })
+                console.log('Failed to poll NR on ', pollUrl, error)
                 statusCode = error.response?.statusCode || 500
             }
             if (statusCode >= 200 && statusCode < 500) {


### PR DESCRIPTION
## Description

This modifies the URL used to poll Node-RED health status to use `http://127.0.0.1/...` rather than the external url for the project.

This should address the two main causes for the hang detection to trigger incorrectly:

 - use of custom TLS certs (using http against localhost avoids the TLS issue)
 - use of the externally routed name (avoids DNS issues inside the containers)

Tested locally with localfs - needs verifiying on staging before we release.