### PR TITLE
Change oauth scope for httpNode middleware requests

### DIFF
--- a/lib/auth/httpAuthMiddleware.js
+++ b/lib/auth/httpAuthMiddleware.js
@@ -45,7 +45,7 @@ module.exports = {
             tokenURL,
             callbackURL,
             userInfoURL,
-            scope: `editor-${version}`,
+            scope: `httpAuth-${version}`,
             clientID: options.clientID,
             clientSecret: options.clientSecret,
             pkce: true,


### PR DESCRIPTION
Part of https://github.com/flowforge/flowforge/issues/1924

## Description

Changes the oauth scope used when accessing http endpoints. This allows the platform to distinguish between editor and non-editor routes and decide whether the user has access.

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
        No - we don't have client-side tests setup for this area currently.
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

