### PR TITLE
Version bump  sub project `nr-theme`  for initial (manual) publish

### DIFF
--- a/lib/theme/package.json
+++ b/lib/theme/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flowforge/nr-theme",
-    "version": "0.2.0",
+    "version": "1.8.0",
     "description": "FlowForge themes for Node-RED",
     "scripts": {
         "prepack": "node scripts/prepack.mjs",


### PR DESCRIPTION
## Description

Version bump sub project `nr-theme` to 1.8.0 (as per current release) so that when we can publish latest agent with a dependancy on 1.8.0 (need to `npm i` to get package lock updated.

## Related Issue(s)

https://github.com/flowforge/flowforge-device-agent/issues/89

## Checklist


 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

