### PR TITLE
Prevent NODE_RED_ENABLE_PROJECTS

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -284,6 +284,10 @@ class Launcher {
             appEnv.HOME = process.env.HOME
         }
 
+        if (appEnv.NODE_RED_ENABLE_PROJECTS) {
+            delete appEnv.NODE_RED_ENABLE_PROJECTS
+        }
+
         appEnv.NODE_PATH = [
             path.join(require.main.path, 'node_modules'),
             path.join(require.main.path, '..', '..')


### PR DESCRIPTION
fixes #140

## Description

<!-- Describe your changes in detail -->
Prevent the NODE_RED_ENABLE_PROJECTS environment variable from being set and passed to the instance.

## Related Issue(s)

<!-- What issue does this PR relate to? -->
#140 

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

