### PR TITLE
Editor Node-RED app environment variables: allow controllable propagation of env set to process to Node-RED app

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,7 @@ The following Environment Variables can be used instead of the cmd line args...
 `FORGE_URL`, `FORGE_TEAM_ID`, `FORGE_PROJECT_ID`, `FORGE_PROJECT_TOKEN`, `FORGE_NR_PATH`, `FORGE_NR_NO_TCP_IN`, `FORGE_NR_NO_UDP_IN`
 
 NOTE: cmd line args take precedent if both are provided
+
+The suggested enhancement is to enable the transfer of environment variables from the host process to Node-RED. 
+This modification, for example, would allow cloud solutions developed within Node-RED to adopt the web identity 
+configurations set on the hosting machines.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ The following Environment Variables can be used instead of the cmd line args...
 
 NOTE: cmd line args take precedent if both are provided
 
-The suggested enhancement is to enable the transfer of environment variables from the host process to Node-RED. 
-This modification, for example, would allow cloud solutions developed within Node-RED to adopt the web identity 
-configurations set on the hosting machines.
+By default, the launcher does not pass host environment variables through to the Node-RED process; only setting the built-in env vars and those configured in the instance settings.
+
+However, if `FORGE_EXPOSE_HOST_ENV` is set, the launcher will pass through all env vars - except that starting with `FORGE_*`.

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -270,14 +270,14 @@ class Launcher {
             return
         }
         this.logBuffer.add({ level: 'system', msg: 'Starting Node-RED' })
-        const filter_env = (env) =>
+        const filterEnv = (env) =>
             Object.entries(env).reduce((acc, [key, value]) =>
-                key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
+                key.startsWith('FORGE') ? acc : { ...acc, [key]: value }, {})
 
         // According to https://github.com/flowforge/flowforge-nr-launcher/pull/145,
         // setting FORGE_EXPOSE_HOST_ENV on the container unlocks the host env propagation.
         const appEnv = Object.assign({},
-            process.env.FORGE_EXPOSE_HOST_ENV ? filter_env(process.env) : {},
+            process.env.FORGE_EXPOSE_HOST_ENV ? filterEnv(process.env) : {},
             this.env,
             this.settings.env)
         appEnv.TZ = this.settings.settings.timeZone

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -273,8 +273,11 @@ class Launcher {
         const filter_env = (env) =>
             Object.entries(env).reduce((acc, [key, value]) =>
                 key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
+
+        // According to https://github.com/flowforge/flowforge-nr-launcher/pull/145,
+        // setting FORGE_EXPOSE_HOST_ENV on the container unlocks the host env propagation.
         const appEnv = Object.assign({},
-            this.settings.env.FORGE_EXPOSE_HOST_ENV ? filter_env(process.env) : {},
+            process.env.FORGE_EXPOSE_HOST_ENV ? filter_env(process.env) : {},
             this.env,
             this.settings.env)
         appEnv.TZ = this.settings.settings.timeZone

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -270,7 +270,13 @@ class Launcher {
             return
         }
         this.logBuffer.add({ level: 'system', msg: 'Starting Node-RED' })
-        const appEnv = Object.assign({}, this.env, this.settings.env)
+        const filter_env = (env) =>
+            Object.entries(env).reduce((acc, [key, value]) =>
+                key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
+        const appEnv = Object.assign({},
+            this.settings.env.FORGE_ALLOW_MANAGED_ENV_IN_EDITOR ? filter_env(process.env) : {},
+            this.env,
+            this.settings.env)
         appEnv.TZ = this.settings.settings.timeZone
 
         if (this.targetState === States.SAFE) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -274,7 +274,7 @@ class Launcher {
             Object.entries(env).reduce((acc, [key, value]) =>
                 key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
         const appEnv = Object.assign({},
-            this.settings.env.FORGE_ALLOW_MANAGED_ENV_IN_EDITOR ? filter_env(process.env) : {},
+            this.settings.env.FORGE_EXPOSE_HOST_ENV ? filter_env(process.env) : {},
             this.env,
             this.settings.env)
         appEnv.TZ = this.settings.settings.timeZone


### PR DESCRIPTION
## Description

### Environment variables, sources
In the environment that the Node-RED process operates, there are 3 sources for the environmental variables:

1. Variables set on the project settings in FlowForge.
2. Variables related to FlowForge project identification. 
3. Variables that come into play when the Editor instance (and by extension, the Device instance, though that's a separate discussion) is deployed via a container orchestrator (dynamically provisioned)

### Share env variables to software running with Node-RED
To forward environment variables to Node-RED (as well as software solutions running in Node-RED), we need to imbue the launcher with the ability to augment the application's environment with env from source 3 - e.g. those that are set on `process.env`. 

### Way to share env
Instead of the usual [way that Node-RED process will assume env](https://github.com/flowforge/flowforge-nr-launcher/blob/8b1a2793f82fb43dcf3df2c2429308a832ec1d80/lib/launcher.js#L273) includes:
- env set on Project Settings in FlowForge
- env with FF project identification needed for Node-RED to communicate to storage via storage plugin

E.g. instead
```javascript
const appEnv = Object.assign({}, this.env, this.settings.env)
```

We propose to filter the `process.env` to exclude variables starting with "FORGE", which stands for servicing FORGE secrets:
```javascript
const filter_env = (env) =>
    Object.entries(env).reduce((acc, [key, value]) =>
          key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
const appEnv = Object.assign({}, filter_env(process.env), this.env, this.settings.env)
```

Or alternatively, in a more controlled approach, we propose using a documented environment variable, such as `FORGE_ALLOW_MANAGED_ENV_IN_EDITOR`. This variable should be set on the project setting to unlock this propagation. This approach ensures that users are aware of the implications and potential benefits of the propagation.

```javascript
const filter_env = (env) =>
    Object.entries(env).reduce((acc, [key, value]) =>
          key.startsWith('FORGE') ? acc : {...acc, [key]: value}, {});
        
const appEnv = Object.assign({},
    this.settings.env.FORGE_ALLOW_MANAGED_ENV_IN_EDITOR ? filter_env(process.env) : {}, 
    this.env, 
    this.settings.env)
```

## Related Issue(s)

[Editor environment variables: allow controllable propagation of env set to Editor process with the hosting operators ](https://github.com/flowforge/flowforge-nr-launcher/issues/144)

## Checklist

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass
 - [x] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

