### PR TITLE
settings: Inject custom catalogues into NR settings

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -1,4 +1,4 @@
-function getSettingsFile(settings) {
+function getSettingsFile (settings) {
     const projectSettings = {
         credentialSecret: '',
         httpAdminRoot: '',
@@ -15,7 +15,7 @@ function getSettingsFile(settings) {
             nodesExcludes: [],
             denyList: [],
             allowList: ['*'],
-            catalogues: ["https://catalogue.nodered.org/catalogue.json"]
+            catalogues: ['https://catalogue.nodered.org/catalogue.json']
         },
         modules: {
             allowInstall: true,

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -1,4 +1,4 @@
-function getSettingsFile (settings) {
+function getSettingsFile(settings) {
     const projectSettings = {
         credentialSecret: '',
         httpAdminRoot: '',
@@ -14,7 +14,8 @@ function getSettingsFile (settings) {
             allowInstall: true,
             nodesExcludes: [],
             denyList: [],
-            allowList: ['*']
+            allowList: ['*'],
+            catalogues: ["https://catalogue.nodered.org/catalogue.json"]
         },
         modules: {
             allowInstall: true,
@@ -172,6 +173,10 @@ function getSettingsFile (settings) {
             token: settings.projectToken
         }
         projectSettings.libraries = `library: { sources: [ ${JSON.stringify(sharedLibraryConfig)} ] },`
+
+        if (settings.settings.palette?.catalogues !== undefined) {
+            projectSettings.palette.catalogues = settings.settings.palette.catalogues
+        }
     }
 
     const settingsTemplate = `
@@ -271,7 +276,8 @@ module.exports = {
             allowInstall: ${projectSettings.palette.allowInstall},
             allowUpload: false,
             denyList: ${JSON.stringify(projectSettings.palette.denyList)},
-            allowList: ${JSON.stringify(projectSettings.palette.allowList)}
+            allowList: ${JSON.stringify(projectSettings.palette.allowList)},
+            catalogues: ${JSON.stringify(projectSettings.palette.catalogues)}
         },
         modules: {
             allowInstall: ${projectSettings.modules.allowInstall},

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -173,7 +173,7 @@ describe('Runtime Settings', function () {
             settings.externalModules.palette.should.have.property('allowUpload', false)
             settings.externalModules.palette.should.have.property('allowList', ['a', 'b', 'c'])
             settings.externalModules.palette.should.have.property('denyList', ['1', '2', '3'])
-            settings.externalModules.palette.should.have.property('catalogues', ["https://foo.bar/list.json", "https://example.com/catalogue.json"])
+            settings.externalModules.palette.should.have.property('catalogues', ['https://foo.bar/list.json', 'https://example.com/catalogue.json'])
 
             settings.externalModules.should.have.property('modules')
             settings.externalModules.modules.should.have.property('allowInstall', false)

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -60,6 +60,7 @@ describe('Runtime Settings', function () {
             settings.externalModules.palette.should.have.property('allowUpload', false)
             settings.externalModules.palette.should.have.property('denyList', [])
             settings.externalModules.palette.should.have.property('allowList', ['*'])
+            settings.externalModules.palette.should.have.property('catalogues', ['https://catalogue.nodered.org/catalogue.json'])
             settings.externalModules.should.have.property('modules')
             settings.externalModules.modules.should.have.property('allowInstall', true)
             settings.externalModules.modules.should.have.property('denyList', [])
@@ -115,7 +116,10 @@ describe('Runtime Settings', function () {
                         allowInstall: false,
                         nodesExcludes: 'abc,def',
                         allowList: ['a', 'b', 'c'],
-                        denyList: ['1', '2', '3']
+                        denyList: ['1', '2', '3'],
+                        catalogues: [
+                            'https://foo.bar/list.json', 'https://example.com/catalogue.json'
+                        ]
                     },
                     modules: {
                         allowInstall: false,
@@ -169,6 +173,7 @@ describe('Runtime Settings', function () {
             settings.externalModules.palette.should.have.property('allowUpload', false)
             settings.externalModules.palette.should.have.property('allowList', ['a', 'b', 'c'])
             settings.externalModules.palette.should.have.property('denyList', ['1', '2', '3'])
+            settings.externalModules.palette.should.have.property('catalogues', ["https://foo.bar/list.json", "https://example.com/catalogue.json"])
 
             settings.externalModules.should.have.property('modules')
             settings.externalModules.modules.should.have.property('allowInstall', false)


### PR DESCRIPTION
By default this change does only make the catalogue settings as by default in Node-RED explicit. There's a side-effect when this catalogue ever changes the default, though ever other instance has to perform an update too in that case.

When an instance is licensed it has the opportunity to override the catalogues with a custom set. This would allow the FlowForge application to control what catalogue is available for the end-user.

## Related Issue(s)

Plumbing needed for: https://github.com/flowforge/flowforge/issues/217

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [X] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [X] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production
