### PR TITLE
Fix wait on deferredStop when trying to start a stopping instance

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -253,7 +253,7 @@ class Launcher {
 
     async start (targetState) {
         if (this.deferredStop) {
-            await this.deferredStop()
+            await this.deferredStop
         }
         if (targetState) {
             this.targetState = targetState


### PR DESCRIPTION
## Description

If a launcher is asked to start an instance that is still stopping, it was hitting an error. This fixes that err
