### PR TITLE
Fix node_path when running in dev-env

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -68,7 +68,7 @@ class Launcher {
         this.runDurations = []
 
         this.logBuffer = new LogBuffer(this.options.logBufferMax || 1000)
-        this.logBuffer.add({ level: 'system', msg: 'Launcher Started' })
+        this.logBuffer.add({ level: 'system', msg: `Launcher version: ${this.options?.versions?.launcher || 'unknown'}` })
 
         // A callback function that will be set if the launcher is waiting
         // for Node-RED to exit
@@ -288,11 +288,21 @@ class Launcher {
             delete appEnv.NODE_RED_ENABLE_PROJECTS
         }
 
-        appEnv.NODE_PATH = [
+        const nodePaths = [
             path.join(require.main.path, 'node_modules'),
             path.join(require.main.path, '..', '..')
-        ].join(path.delimiter)
+        ]
 
+        // Check to see if we're in the dev-env - in which case, we need to add the right
+        // path to NODE_PATH so that the settings file can load `@flowforge/nr-launcher/*`
+        // We have to point at the driver-localfs node_modules as that will have the right paths
+        // in place to load this module.
+        const devEnvPath = path.join(require.main.path, '..', 'flowforge-driver-localfs', 'node_modules')
+        if (fs.existsSync(devEnvPath)) {
+            nodePaths.push(devEnvPath)
+        }
+
+        appEnv.NODE_PATH = nodePaths.join(path.delimiter)
         appEnv.LAUNCHER_VERSION = this.settings.launcherVersion
 
         const processOptions = {


### PR DESCRIPTION
## Description
Recent changes to dev-env means the NODE_PATH wasn't setup correctly when running under dev-env with symlinks in place.

It would fail to start an instance in localfs mode as it couldn't find the `@flowforge/nr-launcher/authMiddleware` export of this module.

For that to work, I had to add the expected path of the localfs driver's node_modules directory when running in dev-env - nothing else worked. I've added a guard around it to only add to the path if the expected dir exists.

I've also slipped a small change to the startup log message of launcher to include the version number... meant to do that separately, but is slipped in and here we are.


<img width="233" alt="image" src="https://github.com/flowforge/flowforge-nr-launcher/assets/51083/89b10b95-3fb7-47dc-846e-3ea113ab7f7e">
