### PR TITLE
Ensure TimeZone is passed to NR

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -271,6 +271,7 @@ class Launcher {
         }
         this.logBuffer.add({ level: 'system', msg: 'Starting Node-RED' })
         const appEnv = Object.assign({}, this.env, this.settings.env)
+        appEnv.TZ = this.settings.settings.timeZone
 
         if (this.targetState === States.SAFE) {
             appEnv.NODE_RED_ENABLE_SAFE_MODE = true


### PR DESCRIPTION
Fix for https://community.flowforge.com/t/some-repeat-interval-options-for-inject-node-not-working-in-flowforge/188/6

## Description

<!-- Describe your changes in detail -->
TimeZone not getting set for NR instance

## Related Issue(s)

<!-- What issue does this PR relate to? -->
https://community.flowforge.com/t/some-repeat-interval-options-for-inject-node-not-working-in-flowforge/188/6

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

