### PR TITLE
Use feature flag to enable shared library

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -182,7 +182,8 @@ function getSettingsFile (settings) {
             token: settings.projectToken
         }
         projectSettings.libraries = `library: { sources: [ ${JSON.stringify(sharedLibraryConfig)} ] },`
-
+    }
+    if (settings.licenseType === 'ee') {
         if (settings.settings.palette?.catalogues !== undefined) {
             projectSettings.palette.catalogues = settings.settings.palette.catalogues
         }

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -170,8 +170,7 @@ function getSettingsFile (settings) {
     if (settings.nodesDir && settings.nodesDir.length) {
         nodesDir = `nodesDir: ${JSON.stringify(settings.nodesDir)},`
     }
-
-    if (settings.licenseType === 'ee') {
+    if (settings.features?.['shared-library']) {
         const sharedLibraryConfig = {
             id: 'flowforge-team-library',
             type: 'flowforge-team-library',

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -160,8 +160,8 @@ describe('Runtime Settings', function () {
             settings.editorTheme.should.have.property('codeEditor')
             settings.editorTheme.codeEditor.should.have.property('lib', 'ace')
 
-            // Should have editorTheme.library as it is an EE feature
-            settings.editorTheme.should.have.property('library')
+            // Should not have editorTheme.library as it is an EE feature but the feature flag wasn't set
+            settings.editorTheme.should.not.have.property('library')
 
             settings.should.have.property('nodesExcludes', ['abc', 'def'])
 
@@ -317,5 +317,16 @@ describe('Runtime Settings', function () {
         settings.should.have.property('disableEditor', true)
         settings.flowforge.should.have.property('projectLink')
         settings.flowforge.projectLink.should.have.property('useSharedSubscriptions', true)
+    })
+    it('includes shared library when feature flag set', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            features: {
+                'shared-library': true
+            },
+            settings: {}
+        })
+        const settings = await loadSettings(result)
+        // Should not have editorTheme.library as it is an EE feature but the feature flag wasn't set
+        settings.editorTheme.should.have.property('library')
     })
 })


### PR DESCRIPTION
## Description

This is part of https://github.com/flowforge/flowforge/issues/2531 and should not be merged until the flowforge side of these changes are made.

This modifies how the launcher decides whether the shared-library feature is available. Instead of simply using the presence of an EE license, it will now use flags passed to it from the platform. This will the decision to be made centrally based on whether the feature is enabled for the corresponding team type.
