### PR TITLE
Use projectComms feature flag to enable comms nodes

### DIFF
--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -125,7 +125,7 @@ function getSettingsFile (settings) {
         }
     }
 
-    if (settings.licenseType === 'ee' && settings.broker) {
+    if (settings.features?.projectComms && settings.broker) {
         // Enable the projectLink nodes if a broker configuration is provided
         projectSettings.projectLink = {
             token: settings.projectToken,

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -185,13 +185,9 @@ describe('Runtime Settings', function () {
             settings.flowforge.should.have.property('forgeURL', 'FORGEURL')
             settings.flowforge.should.have.property('teamID', 'TEAMID')
             settings.flowforge.should.have.property('projectID', 'PROJECTID')
-            settings.flowforge.should.have.property('projectLink')
-            settings.flowforge.projectLink.should.have.property('token', 'PROJECTTOKEN')
-            settings.flowforge.projectLink.should.have.property('broker')
-            settings.flowforge.projectLink.broker.should.have.property('url', 'BROKERURL')
-            settings.flowforge.projectLink.broker.should.have.property('username', 'BROKERUSERNAME')
-            settings.flowforge.projectLink.broker.should.have.property('password', 'BROKERPASSWORD')
-            settings.flowforge.projectLink.should.not.have.property('useSharedSubscriptions')
+
+            // Should not have projectLink as it is an EE feature but the feature flag wasn't set
+            settings.flowforge.should.not.have.property('projectLink')
         })
         it('does not include projectLink if licenseType not ee', async function () {
             const result = runtimeSettings.getSettingsFile({
@@ -307,6 +303,9 @@ describe('Runtime Settings', function () {
                 username: 'BROKERUSERNAME',
                 password: 'BROKERPASSWORD'
             },
+            features: {
+                projectComms: true
+            },
             settings: {
                 ha: {
                     replicas: 2
@@ -326,7 +325,28 @@ describe('Runtime Settings', function () {
             settings: {}
         })
         const settings = await loadSettings(result)
-        // Should not have editorTheme.library as it is an EE feature but the feature flag wasn't set
         settings.editorTheme.should.have.property('library')
+    })
+    it('includes project comms when feature flag set', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            projectToken: 'PROJECTTOKEN',
+            broker: {
+                url: 'BROKERURL',
+                username: 'BROKERUSERNAME',
+                password: 'BROKERPASSWORD'
+            },
+            features: {
+                projectComms: true
+            },
+            settings: {}
+        })
+        const settings = await loadSettings(result)
+        settings.flowforge.should.have.property('projectLink')
+        settings.flowforge.projectLink.should.have.property('token', 'PROJECTTOKEN')
+        settings.flowforge.projectLink.should.have.property('broker')
+        settings.flowforge.projectLink.broker.should.have.property('url', 'BROKERURL')
+        settings.flowforge.projectLink.broker.should.have.property('username', 'BROKERUSERNAME')
+        settings.flowforge.projectLink.broker.should.have.property('password', 'BROKERPASSWORD')
+        settings.flowforge.projectLink.should.not.have.property('useSharedSubscriptions')
     })
 })


### PR DESCRIPTION
## Description

This is part of https://github.com/flowforge/flowforge/issues/2531 and should not be merged until the flowforge side of these changes are made.

Modifies the launcher to use the projectComms feature flag from the platform.

