### PR TITLE
Enable localfs package build dispatcher after package publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,6 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     needs: [nrLauncherPackage, nrThemePackage]
-    if: false
     steps:
       - name: Generate a token
         id: generate_token
@@ -53,11 +52,12 @@ jobs:
         with:
           app_id: ${{ secrets.GH_BOT_APP_ID }}
           private_key: ${{ secrets.GH_BOT_APP_KEY }}
-      - name: Trigger localfs package rebuild
+
+      - name: Trigger localfs package build
         uses: benc-uk/workflow-dispatch@v1
         with:
           workflow: publish.yml
           repo: flowforge/flowforge-driver-localfs
-          ref: feat-publish-pipeline-poc
+          ref: main
           token: ${{ steps.generate_token.outputs.token }}
           inputs: '{"nr_launcher_ref": "${{ github.ref }}", "nr_launcher_release_name": "${{ needs.nrLauncherPackage.outputs.release_name }}"}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,10 @@ jobs:
 
   nrLauncherPackage:
     needs: build
-    # if: |
-    #   ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-    #   github.event_name == 'schedule'
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' ) ||
+      github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-nr-launcher
@@ -55,9 +56,10 @@ jobs:
   
   nrThemePackage:
     needs: build
-    # if: |
-    #   ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-    #   github.event_name == 'schedule'
+    if: |
+      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+      ( github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main' ) ||
+      github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-nr-theme
@@ -82,6 +84,6 @@ jobs:
         with:
           workflow: publish.yml
           repo: flowforge/flowforge-driver-localfs
-          ref: feat-dispatch-flowforge-build
+          ref: main
           token: ${{ steps.generate_token.outputs.token }}
           inputs: '{"nr_launcher_ref": "${{ github.ref }}", "nr_launcher_release_name": "${{ needs.nrLauncherPackage.outputs.release_name }}"}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,4 @@
 name: Build and push packages
-
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,5 @@
 name: Build and push packages
+
 on:
   workflow_dispatch:
     inputs:
@@ -65,6 +66,7 @@ jobs:
       disable_ignore_scripts_on_publish: true
 
   dispatch:
+    name: Dispatch localfs package build pipeline
     runs-on: ubuntu-latest
     needs: [nrLauncherPackage, nrThemePackage]
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,29 @@
 name: Build and push packages
 
 on:
+  workflow_dispatch:
+    inputs:
+      nr_project_nodes_release_name:
+        description: 'nr-project-nodes package version'
+        required: false
+        default: 'nightly'
+      nr_project_nodes_ref:
+        description: 'nr-project-nodes package ref'
+        required: false
+      nr_file_nodes_release_name:
+        description: 'nr-file-nodes package version'
+        required: false
+        default: 'nightly'
+      nr_file_nodes_ref:
+        description: 'nr-file-nodes package ref'
+        required: false
+      nr_persistent_context_release_name:
+        description: 'nr-persistent-context package version'
+        required: false
+        default: 'nightly'
+      nr_persistent_context_ref:
+        description: 'nr-persistent-context package ref'
+        required: false
   schedule:
     - cron: '0 23 * * *'
   pull_request:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,6 +80,6 @@ jobs:
         with:
           workflow: publish.yml
           repo: flowforge/flowforge-driver-localfs
-          ref: main
+          ref: feat-dispatch-flowforge-build
           token: ${{ steps.generate_token.outputs.token }}
           inputs: '{"nr_launcher_ref": "${{ github.ref }}", "nr_launcher_release_name": "${{ needs.nrLauncherPackage.outputs.release_name }}"}'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,9 +41,9 @@ jobs:
 
   nrLauncherPackage:
     needs: build
-    if: |
-      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-      github.event_name == 'schedule'
+    # if: |
+    #   ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+    #   github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-nr-launcher
@@ -55,9 +55,9 @@ jobs:
   
   nrThemePackage:
     needs: build
-    if: |
-      ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
-      github.event_name == 'schedule'
+    # if: |
+    #   ( github.event_name == 'push' && github.ref == 'refs/heads/main' ) ||
+    #   github.event_name == 'schedule'
     uses: 'flowforge/github-actions-workflows/.github/workflows/publish_node_package.yml@main'
     with:
       package_name: flowforge-nr-theme


### PR DESCRIPTION
## Description

Enable localfs package build dispatcher after package publish.

## Related Issue(s)

<!-- What issue does this PR relate to? -->

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [ ] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

