### PR TITLE
Add support for custom node catalogues

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -138,8 +138,8 @@ class Launcher {
             this.logBuffer.add({ level: 'system', msg: 'Unable to write package file' })
             throw error
         }
+        const npmrcPath = path.join(this.settings.rootDir, this.settings.userDir, '.npmrc')
         if (this.settings.settings.palette.npmrc) {
-            const npmrcPath = path.join(this.settings.rootDir, this.settings.userDir, '.npmrc')
             try {
                 fs.writeFileSync(npmrcPath, this.settings.settings.palette.npmrc)
             } catch (error) {
@@ -147,7 +147,18 @@ class Launcher {
                 this.logBuffer.add({ level: 'system', msg: 'Unable to write .npmrc file' })
                 throw error
             }
+        } else {
+            if (fs.existsSync(npmrcPath)) {
+                try {
+                    fs.unlinkSync(npmrcPath)
+                } catch (error) {
+                    this.state = States.STOPPED
+                    this.logBuffer.add({ level: 'system', msg: 'Unable to remove old .npmrc file' })
+                    throw error
+                }
+            }
         }
+
         try {
             await this.updatePackage()
         } catch (error) {

--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -138,6 +138,16 @@ class Launcher {
             this.logBuffer.add({ level: 'system', msg: 'Unable to write package file' })
             throw error
         }
+        if (this.settings.settings.palette.npmrc) {
+            const npmrcPath = path.join(this.settings.rootDir, this.settings.userDir, '.npmrc')
+            try {
+                fs.writeFileSync(npmrcPath, this.settings.settings.palette.npmrc)
+            } catch (error) {
+                this.state = States.STOPPED
+                this.logBuffer.add({ level: 'system', msg: 'Unable to write .npmrc file' })
+                throw error
+            }
+        }
         try {
             await this.updatePackage()
         } catch (error) {

--- a/lib/runtimeSettings.js
+++ b/lib/runtimeSettings.js
@@ -184,8 +184,8 @@ function getSettingsFile (settings) {
         projectSettings.libraries = `library: { sources: [ ${JSON.stringify(sharedLibraryConfig)} ] },`
     }
     if (settings.licenseType === 'ee') {
-        if (settings.settings.palette?.catalogues !== undefined) {
-            projectSettings.palette.catalogues = settings.settings.palette.catalogues
+        if (settings.settings.palette?.catalogue !== undefined) {
+            projectSettings.palette.catalogues = settings.settings.palette.catalogue
         }
     }
 
@@ -277,7 +277,10 @@ module.exports = {
             lib: '${projectSettings.codeEditor}'
         },
         ${projectSettings.libraries}
-        tours: ${projectSettings.tours}
+        tours: ${projectSettings.tours},
+        palette: {
+            catalogues: ${JSON.stringify(projectSettings.palette.catalogues)}
+        }
     },
     nodesExcludes: ${JSON.stringify(projectSettings.palette.nodesExcludes)},
     externalModules: {
@@ -286,8 +289,7 @@ module.exports = {
             allowInstall: ${projectSettings.palette.allowInstall},
             allowUpload: false,
             denyList: ${JSON.stringify(projectSettings.palette.denyList)},
-            allowList: ${JSON.stringify(projectSettings.palette.allowList)},
-            catalogues: ${JSON.stringify(projectSettings.palette.catalogues)}
+            allowList: ${JSON.stringify(projectSettings.palette.allowList)}
         },
         modules: {
             allowInstall: ${projectSettings.modules.allowInstall},

--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -60,7 +60,6 @@ describe('Runtime Settings', function () {
             settings.externalModules.palette.should.have.property('allowUpload', false)
             settings.externalModules.palette.should.have.property('denyList', [])
             settings.externalModules.palette.should.have.property('allowList', ['*'])
-            settings.externalModules.palette.should.have.property('catalogues', ['https://catalogue.nodered.org/catalogue.json'])
             settings.externalModules.should.have.property('modules')
             settings.externalModules.modules.should.have.property('allowInstall', true)
             settings.externalModules.modules.should.have.property('denyList', [])
@@ -116,10 +115,7 @@ describe('Runtime Settings', function () {
                         allowInstall: false,
                         nodesExcludes: 'abc,def',
                         allowList: ['a', 'b', 'c'],
-                        denyList: ['1', '2', '3'],
-                        catalogues: [
-                            'https://foo.bar/list.json', 'https://example.com/catalogue.json'
-                        ]
+                        denyList: ['1', '2', '3']
                     },
                     modules: {
                         allowInstall: false,
@@ -173,7 +169,6 @@ describe('Runtime Settings', function () {
             settings.externalModules.palette.should.have.property('allowUpload', false)
             settings.externalModules.palette.should.have.property('allowList', ['a', 'b', 'c'])
             settings.externalModules.palette.should.have.property('denyList', ['1', '2', '3'])
-            settings.externalModules.palette.should.have.property('catalogues', ['https://foo.bar/list.json', 'https://example.com/catalogue.json'])
 
             settings.externalModules.should.have.property('modules')
             settings.externalModules.modules.should.have.property('allowInstall', false)
@@ -348,5 +343,37 @@ describe('Runtime Settings', function () {
         settings.flowforge.projectLink.broker.should.have.property('username', 'BROKERUSERNAME')
         settings.flowforge.projectLink.broker.should.have.property('password', 'BROKERPASSWORD')
         settings.flowforge.projectLink.should.not.have.property('useSharedSubscriptions')
+    })
+    it('sets catalogue when EE and setting is present', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            licenseType: 'ee',
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            }
+        })
+        const settings = await loadSettings(result)
+        settings.editorTheme.should.have.property('palette')
+        settings.editorTheme.palette.should.have.property('catalogues').and.be.an.Array()
+        settings.editorTheme.palette.catalogues.should.have.length(3)
+        settings.editorTheme.palette.catalogues[0].should.eql('foo')
+        settings.editorTheme.palette.catalogues[1].should.eql('bar')
+        settings.editorTheme.palette.catalogues[2].should.eql('baz')
+    })
+    it('ignores catalogue entries when NOT EE and setting is present', async function () {
+        const result = runtimeSettings.getSettingsFile({
+            // licenseType: 'ee', << no license type
+            settings: {
+                palette: {
+                    catalogue: ['foo', 'bar', 'baz']
+                }
+            }
+        })
+        const settings = await loadSettings(result)
+        settings.editorTheme.should.have.property('palette')
+        settings.editorTheme.palette.should.have.property('catalogues').and.be.an.Array()
+        settings.editorTheme.palette.catalogues.should.have.length(1)
+        settings.editorTheme.palette.catalogues[0].should.not.eql('foo') // will be NR default catalogue
     })
 })


### PR DESCRIPTION
part of flowforge/flowforge#2526

## Description

<!-- Describe your changes in detail -->
Adds list of node catalogues to `settings.js`

Also writes custom .npmrc if required (and cleans up if not)

## Related Issue(s)

<!-- What issue does this PR relate to? -->
flowforge/flowforge#2526

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

