### PR TITLE
Update npm install command to remove production warning

### DIFF
--- a/lib/launcher.js
+++ b/lib/launcher.js
@@ -185,7 +185,7 @@ class Launcher {
             return new Promise((resolve, reject) => {
                 const child = childProcess.spawn(
                     npmCommand,
-                    ['install', '--production', '--no-audit', '--no-update-notifier', '--no-fund'],
+                    ['install', '--omit=dev', '--no-audit', '--no-update-notifier', '--no-fund'],
                     { windowsHide: true, cwd: path.join(this.settings.rootDir, this.settings.userDir) })
                 child.stdout.on('data', (data) => {
                     this.logBuffer.add({ level: 'system', msg: '[npm] ' + data })


### PR DESCRIPTION
## Description

We have been using `npm install --production` for a long time. npm has been telling us to use the far-less memorable `--omit=dev` for some time.... so this PR does just that.
