### PR TITLE
Fix tests on windows - ensure forward  slashes on paths

### DIFF
--- a/test/unit/lib/runtimeSettings_spec.js
+++ b/test/unit/lib/runtimeSettings_spec.js
@@ -22,7 +22,7 @@ describe('Runtime Settings', function () {
         const nmPath2 = path.normalize(path.join(__dirname, '../../../../../node_modules')).split(path.sep).join('/')
         // Rewrite any requires for exports of this module
         content = content.replace(/'(@flowforge\/nr-launcher\/.*)'/g, (match, p1) => {
-            return `'${require.resolve(p1)}'`
+            return `'${require.resolve(p1).split(path.sep).join('/')}'`
         })
         content = `module.paths.unshift('${nmPath}', '${nmPath2}'); ${content}`
         const fn = path.normalize(path.join(TMPDIR, `${Math.random().toString(36).substring(2)}.js`)).split(path.sep).join('/')


### PR DESCRIPTION
closes #171

## Description

Fixes test runner on windows.

Force use of forward slashes

## Related Issue(s)

#171

## Checklist

<!-- https://flowforge.com/handbook/development/#defining-done -->

 - [x] I have read the [contribution guidelines](https://github.com/flowforge/flowforge/blob/main/CONTRIBUTING.md)
 - [x] Suitable unit/system level tests have been added and they pass <!-- If not adding test coverage, please clarify why not? -->
 - [ ] Documentation has been updated
    - [ ] Upgrade instructions
    - [ ] Configuration details
    - [ ] Concepts
 - [ ] Changes `flowforge.yml`?
    - [ ] Issue/PR raised on `flowforge/helm` to update ConfigMap Template
    - [ ] Issue/PR raised on `flowforge/CloudProject` to update values for Staging/Production

## Labels

 - [ ] Backport needed? -> add the `backport` label
 - [ ] Includes a DB migration? -> add the `area:migration` label

